### PR TITLE
MACDC-4144 replace all rec add ts variables to use timestamp instead of da run id as its no longer valid

### DIFF
--- a/taf/APL/BASE.py
+++ b/taf/APL/BASE.py
@@ -460,7 +460,7 @@ class BASE(APL):
             SELECT
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
-                ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM base_{self.year}_final
             """

--- a/taf/APL/ENRLMT.py
+++ b/taf/APL/ENRLMT.py
@@ -77,7 +77,7 @@ class ENRLMT(APL):
             SELECT
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
-                ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM enrlmt_pl_{self.year}
             """

--- a/taf/APL/LCTN.py
+++ b/taf/APL/LCTN.py
@@ -99,7 +99,7 @@ class LCTN(APL):
             SELECT
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
-                ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM lctn_pl_{self.year}
             """            

--- a/taf/APL/OA.py
+++ b/taf/APL/OA.py
@@ -210,7 +210,7 @@ class OA(APL):
             SELECT
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
-                ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM OpAuth1
             """

--- a/taf/APL/SAREA.py
+++ b/taf/APL/SAREA.py
@@ -86,7 +86,7 @@ class SAREA(APL):
             SELECT
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
-                ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM sarea_pl_{self.year}
             """            

--- a/taf/APR/BASE.py
+++ b/taf/APR/BASE.py
@@ -234,7 +234,7 @@ class BASE(APR):
             SELECT
                  { self.table_id_cols() }
                 ,{ ','.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM base_{self.year}_final"""
 

--- a/taf/APR/BED.py
+++ b/taf/APR/BED.py
@@ -66,7 +66,7 @@ class BED(APR):
             SELECT
                 {self.table_id_cols(loctype=2)}
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM bed_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/ENR.py
+++ b/taf/APR/ENR.py
@@ -72,7 +72,7 @@ class ENR(APR):
             SELECT
                 {self.table_id_cols()}
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM enrlmt_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/GRP.py
+++ b/taf/APR/GRP.py
@@ -62,7 +62,7 @@ class GRP(APR):
             SELECT
                 {self.table_id_cols()}
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM grp_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/IDT.py
+++ b/taf/APR/IDT.py
@@ -166,7 +166,7 @@ class IDT(APR):
             SELECT
                 {self.table_id_cols(loctype=2)}
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM id_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/LIC.py
+++ b/taf/APR/LIC.py
@@ -69,7 +69,7 @@ class LIC(APR):
             SELECT
                 {self.table_id_cols(loctype=2)}
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM lcns_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/LOC.py
+++ b/taf/APR/LOC.py
@@ -88,7 +88,7 @@ class LOC(APR):
                 SELECT
                     {self.table_id_cols(loctype=1)}
                     ,{ ', '.join(basecols) }
-                    ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                    ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                     ,current_timestamp() as REC_UPDT_TS
                 FROM lctn_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/PGM.py
+++ b/taf/APR/PGM.py
@@ -64,7 +64,7 @@ class PGM(APR):
             SELECT
                  { self.table_id_cols() }
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM pgm_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/TAX.py
+++ b/taf/APR/TAX.py
@@ -65,7 +65,7 @@ class TAX(APR):
             SELECT
                 {self.table_id_cols()}
                 ,{ ', '.join(basecols) }
-                ,to_timestamp('{self.apr.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,current_timestamp() as REC_UPDT_TS
             FROM txnmy_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)

--- a/taf/DE/DE.py
+++ b/taf/DE/DE.py
@@ -4,15 +4,15 @@ from taf.TAF import TAF
 
 class DE(TAF):
     """
-    Annual Demographic and Eligibility (DE) TAF: The annual DE TAF contain demographic, 
-    eligibility, and enrollment information for all Medicaid and CHIP beneficiaries who 
-    were enrolled for at least one day during each calendar year; there is also a “dummy” 
-    record for each beneficiary who had claims information during the year but no 
-    corresponding eligibility information. Each annual DE TAF is comprised of eight 
-    files:  a Base file; Eligibility Dates file; Name, Address & Phone file; Managed Care file; 
-    Waiver file; Money Follows the Person file; Health Home & State Plan Option file; 
-    and Disability and Need file. All eight files can be linked together using unique keys 
-    that are constructed based on various data elements.  The annual DE TAF are created 
+    Annual Demographic and Eligibility (DE) TAF: The annual DE TAF contain demographic,
+    eligibility, and enrollment information for all Medicaid and CHIP beneficiaries who
+    were enrolled for at least one day during each calendar year; there is also a “dummy”
+    record for each beneficiary who had claims information during the year but no
+    corresponding eligibility information. Each annual DE TAF is comprised of eight
+    files:  a Base file; Eligibility Dates file; Name, Address & Phone file; Managed Care file;
+    Waiver file; Money Follows the Person file; Health Home & State Plan Option file;
+    and Disability and Need file. All eight files can be linked together using unique keys
+    that are constructed based on various data elements.  The annual DE TAF are created
     solely from the monthly BSF TAF.
     """
 
@@ -136,7 +136,7 @@ class DE(TAF):
         """
         self.de.append(type(self).__name__, z)
         print(f"""Creating Temp Table: {tblname}_{inyear}""")
- 
+
     def mc_type_rank(self, smonth: int, emonth: int):
         """
         Function mc_type_rank to look across all MC types for each month and assign one type for
@@ -147,7 +147,7 @@ class DE(TAF):
             smonth=the month to begin looping over, where default=1.
             emonth=the month to end looping over, where default=12.
         """
-        
+
         priorities = ["01", "04", "05", "06", "15", "07", "14", "17", "08", "09", "10",
                       "11", "12", "13", "19", "18", "16", "02", "03", "60", "70", "80", "20", "99"]
 
@@ -172,10 +172,10 @@ class DE(TAF):
 
     def misg_enrlm_type():
         """
-        Function misg_enrlmt_type to create indicators for ENRL_TYPE_FLAG = NULL. 
-        Set to 1 if ENRL_TYPE_FLAG = NULL AND the person is in the month. 
-        Set to 0 if ENRL_TYPE_FLAG != NULL AND person in the month. 
-        Set to NULL if the person is not in the month. 
+        Function misg_enrlmt_type to create indicators for ENRL_TYPE_FLAG = NULL.
+        Set to 1 if ENRL_TYPE_FLAG = NULL AND the person is in the month.
+        Set to 0 if ENRL_TYPE_FLAG != NULL AND person in the month.
+        Set to NULL if the person is not in the month.
         """
 
         z = ""
@@ -253,7 +253,7 @@ class DE(TAF):
             outcol=column to assign based on the month captured in nonmiss_month
             monthval1=monthly value to evaluate captured in nonmiss_month
             incol1=input column to assign if monthval1 is met
-            monthval2=optional monthly value to evaluate captured in nonmiss_month, IF monthval1=00 
+            monthval2=optional monthly value to evaluate captured in nonmiss_month, IF monthval1=00
             incol2=optional input column to assign if monthval2 is met
         """
 
@@ -287,10 +287,10 @@ class DE(TAF):
     def address_same_year(self, incol):
         """
         Function address_same_year to use yearpull to pull in the address information
-        from the same year in which ELGBL_LINE_1_ADR was pulled 
+        from the same year in which ELGBL_LINE_1_ADR was pulled
 
         Function parms:
-            incol = input col to pull 
+            incol = input col to pull
         """
 
         cnt = 0
@@ -307,9 +307,9 @@ class DE(TAF):
         """
         Function unique_claims_ids to join the max da_run_ids for the given claims file back to the monthly TAF and
         create a table of list of unique state/msis IDs with any claim.
-        These lists will be unioned outside the Function. 
+        These lists will be unioned outside the Function.
         """
-        
+
         z = f"""
             select distinct b.submtg_state_cd
                             ,msis_ident_num
@@ -372,7 +372,7 @@ class DE(TAF):
         Function parms:
             incol=input monthly column
             outcol=name of column to be output, where default is the name of the incol with _MO for each month appended as a suffix
-            nslots=# of slots, default = 16 (# of slots of effective/end dates on the BSF) 
+            nslots=# of slots, default = 16 (# of slots of effective/end dates on the BSF)
             truncfirst=indicator for whether date should be truncated to the first of the month (i.e. date being read in is an effective
                         date), where default = 1. Set to 0 for end dates (truncated to last day of the month)
         """
@@ -430,9 +430,9 @@ class DE(TAF):
         Function parms:
             incol=input type column to evaluate
             values=list of values (waiver or MC types) to look for
-            outcol=output column with indicator for specific type 
+            outcol=output column with indicator for specific type
             smonth=the month to begin looping over, where default=1
-            emonth=the month to end looping over, where default=12 
+            emonth=the month to end looping over, where default=12
         """
 
 
@@ -500,7 +500,7 @@ class DE(TAF):
         incol=input monthly column which will be summed (with _MO suffix for each month)
         raw=indicator for whether the monthly variables are raw (must come from the 12 monthly files) or were created
             in an earlier subquery and will therefore have the _MO suffixes, where default = 0
-        outcol=output column with summation, where the default is the incol name with the _MONTHS suffix 
+        outcol=output column with summation, where the default is the incol name with the _MONTHS suffix
         """
 
         if outcol == "":
@@ -551,7 +551,7 @@ class DE(TAF):
     def mc_nonnull_zero(self, outcol, smonth, emonth):
         """
         Function mc_nonnull_zero to look across all MC IDs AND types slots and create an indicator
-        if there is any non-null/00 value for type OR any non-null/0-, 8- or 9-only value for ID (for the _SPLMTL flags) 
+        if there is any non-null/00 value for type OR any non-null/0-, 8- or 9-only value for ID (for the _SPLMTL flags)
 
         Function parms:
             outcol=name of outcol (supp flag, will have suffix of smonth_emonth and then all must be combined to get
@@ -590,7 +590,7 @@ class DE(TAF):
 
         Function parms:
             incols=input columns
-            outcol=name of column to be output 
+            outcol=name of column to be output
             condition=monthly condition to be evaulated, where default is = 1
         """
 
@@ -616,7 +616,7 @@ class DE(TAF):
         """
         Function join_monthly to join the max da_run_ids for the given state/month back to the monthly TAF and
         then join each month by submtg_state_cd and msis_ident_num. Note this table will be pulled into for the subquery in the
-        creation of each base and supplemental segment. 
+        creation of each base and supplemental segment.
         """
 
         z = f"""(select a.submtg_state_cd,
@@ -662,8 +662,8 @@ class DE(TAF):
 
         Function parms:
             incol=input monthly column
-            outcol=name of column to be output, where default is the same name of the incol 
-            prior=indicator to compare current year against prior years (for demographics) to take prior if current year is missing, where default=0 
+            outcol=name of column to be output, where default is the same name of the incol
+            prior=indicator to compare current year against prior years (for demographics) to take prior if current year is missing, where default=0
         """
 
         z = ''
@@ -692,10 +692,10 @@ class DE(TAF):
     def waiv_nonnull(self, outcol):
         """
         Function waiv_nonnull to look across all waiver IDs AND types slots and create an indicator
-        if there is any non-null value (for the _SPLMTL flags) 
+        if there is any non-null value (for the _SPLMTL flags)
 
         Function parms:
-            outcol=name of outcol (supp flag) 
+            outcol=name of outcol (supp flag)
         """
 
         z = """,case when """
@@ -730,8 +730,8 @@ class DE(TAF):
                 in an earlier subquery and will therefore have the _MO suffixes, where default = 1
             outcol=name of column to be output, where default is the name of the incol with _EVER appended as a suffix
             usenulls=indicator to determine whether to use the nullif function to compare both nulls AND another value,
-                    where default is = 0 
-            nullcond=additional value to look for when usenulls=1 
+                    where default is = 0
+            nullcond=additional value to look for when usenulls=1
         """
 
         if outcol == '':
@@ -808,23 +808,23 @@ class DE(TAF):
 
     def ST_FILTER(self):
         """
-        Use the trim function to remove extraneous space characters from start and end of state names.  
+        Use the trim function to remove extraneous space characters from start and end of state names.
         """
-        
+
         return "and trim(submitting_state) not in ('94','96')"
 
     def max_run_id(self, file="", tbl="", inyear=""):
         """
         Function max_run_id to get the highest da_run_id for the given state for each input monthly TAF (DE or claims). This
         table will then be merged back to the monthly TAF to pull all records for that state, month, and da_run_id.
-        It is also inserted into the metadata table to keep a record of the state/month DA_RUN_IDs that make up 
+        It is also inserted into the metadata table to keep a record of the state/month DA_RUN_IDs that make up
         each annual run.
         To get the max run ID, must go to the job control table and get the latest national run, and then also
         get the latest state-specific run. Determine the later by state and month and then pull those IDs.
 
         Function parms:
             inyear=input year, where the default will be set to the current year but it can be changed to all prior years,
-                    for when we need to read in demographic information from all prior years 
+                    for when we need to read in demographic information from all prior years
         """
 
         if not inyear:
@@ -1010,7 +1010,7 @@ class DE(TAF):
     def create_pyears(self):
         """
         Function create_pyears to create a list of all prior years (from current year minus 1 to 2014).
-        Note for 2014 the list will be empty. 
+        Note for 2014 the list will be empty.
         """
 
         pyears = []

--- a/taf/DE/DE0001BASE.py
+++ b/taf/DE/DE0001BASE.py
@@ -22,7 +22,7 @@ class DE0001BASE(DE):
 
     def create(self):
         """
-        Create the segment.  
+        Create the segment.
         """
 
         self.create_temp()
@@ -236,18 +236,18 @@ class DE0001BASE(DE):
             ,MISG_ENRLMT_TYPE_IND_12
             ,MISG_ELGBLTY_DATA_IND
             ,ELGBLTY_CHG_RSN_CD_01
-			,ELGBLTY_CHG_RSN_CD_02
-			,ELGBLTY_CHG_RSN_CD_03
-			,ELGBLTY_CHG_RSN_CD_04
-			,ELGBLTY_CHG_RSN_CD_05
-			,ELGBLTY_CHG_RSN_CD_06
-			,ELGBLTY_CHG_RSN_CD_07
-			,ELGBLTY_CHG_RSN_CD_08
-			,ELGBLTY_CHG_RSN_CD_09
-			,ELGBLTY_CHG_RSN_CD_10
-			,ELGBLTY_CHG_RSN_CD_11
-			,ELGBLTY_CHG_RSN_CD_12
-			,ELGBL_AFTR_EOY_IND
+            ,ELGBLTY_CHG_RSN_CD_02
+            ,ELGBLTY_CHG_RSN_CD_03
+            ,ELGBLTY_CHG_RSN_CD_04
+            ,ELGBLTY_CHG_RSN_CD_05
+            ,ELGBLTY_CHG_RSN_CD_06
+            ,ELGBLTY_CHG_RSN_CD_07
+            ,ELGBLTY_CHG_RSN_CD_08
+            ,ELGBLTY_CHG_RSN_CD_09
+            ,ELGBLTY_CHG_RSN_CD_10
+            ,ELGBLTY_CHG_RSN_CD_11
+            ,ELGBLTY_CHG_RSN_CD_12
+            ,ELGBL_AFTR_EOY_IND
         """
         return z
 
@@ -388,10 +388,9 @@ class DE0001BASE(DE):
         )
     pass
 
-
     def create_hist_demo(self, tblname, inyear):
         """
-        Create the base demo table.  
+        Create the base demo table.
         """
 
         z = f"""create or replace temporary view {tblname}_{inyear} as
@@ -429,30 +428,30 @@ class DE0001BASE(DE):
                             ,elgbl_state_cd
                             ,msis_case_num
                             ,mdcr_bene_id
-                            ,mdcr_hicn_num		          
-                    from  
+                            ,mdcr_hicn_num
+                    from
                         max_run_id_de_{inyear} a
                     inner join
                         {self.de.DA_SCHEMA}.taf_ann_de_base b
-				    on 
+                    on
                         a.submtg_state_cd = b.submtg_state_cd and
-				        a.da_run_id = b.da_run_id
-				    where 
+                    a.da_run_id = b.da_run_id
+                    where
                         b.misg_elgblty_data_ind = 0
-				    order by 
+                    order by
                         submtg_state_cd,
-				        msis_ident_num       
-			        ) as c
-			    left join 
-                    {self.de.DA_SCHEMA}.taf_ann_de_cntct_dtls as d 
-                on 
+                    msis_ident_num
+                    ) as c
+                    left join
+                    {self.de.DA_SCHEMA}.taf_ann_de_cntct_dtls as d
+                on
                     c.de_link_key = d.de_link_key
             """
         self.de.append(type(self).__name__, z)
 
     def gen_bsf_last_dt(self, tot_month, in_year):
         """
-        Create BSF last date.  
+        Create BSF last date.
         """
 
         gen_bsf_last_dt = []
@@ -467,13 +466,13 @@ class DE0001BASE(DE):
 
     def age_date_calculate(self, inyear):
         """
-        Calculate age date.  
+        Calculate age date.
         """
 
         z = f"""case { self.gen_bsf_last_dt(tot_month=12, in_year=inyear) }
                 end as BSF_LAST_DT,
                 case when BSF_RECORD = '12' then ELGBL_AFTR_EOM_TEMP
-                else 0 
+                else 0
                 end as ELGBL_AFTR_EOY_IND
             """
         return z
@@ -486,7 +485,7 @@ class DE0001BASE(DE):
 
         if self.de.GETPRIOR == 1:
             cnt = 0
-            #for pyear in range(1, self.de.PYEARS + 1):
+            # for pyear in range(1, self.de.PYEARS + 1):
             for pyear in self.de.PYEARS:
                 self.create_hist_demo(tblname="base_demo", inyear=pyear)
 
@@ -522,7 +521,7 @@ class DE0001BASE(DE):
 
                     ,case when c.ELGBL_LINE_1_ADR is not null then {self.de.YEAR}"""+' '
 
-                #for pyear in range(1, self.de.PYEARS + 1):
+            # for pyear in range(1, self.de.PYEARS + 1):
             for pyear in self.de.PYEARS:
                 cnt += 1
                 z += f"""when p{cnt}.ELGBL_LINE_1_ADR is not null then {pyear}"""+' '
@@ -538,7 +537,7 @@ class DE0001BASE(DE):
             cnt = 0
             for pyear in self.de.PYEARS:
                 cnt += 1
-                #for pyear in range(1, self.de.PYEARS + 1):
+                # for pyear in range(1, self.de.PYEARS + 1):
                 z += f"""
                     left join
                     base_demo_{pyear} p{cnt}
@@ -617,22 +616,22 @@ class DE0001BASE(DE):
 
         z = f"""create or replace temporary view base_{self.de.YEAR}_temp1 as
                 select *,
-                    case when AGE_NUM_TEMP is not null then AGE_NUM_TEMP 
+                    case when AGE_NUM_TEMP is not null then AGE_NUM_TEMP
                         when BIRTH_DT is not null then
                         case when DEATH_DT is not null then floor(datediff(DEATH_DT, BIRTH_DT) /365.25)
                             when BSF_RECORD is not null then floor(datediff(BSF_LAST_DT, BIRTH_DT) /365.25)
                         end
-                    else null 
+                    else null
                     end as AGE_NUM_RAW
                 from base_{self.de.YEAR}_temp
             """
-        self.de.append(type(self).__name__, z)        
+        self.de.append(type(self).__name__, z)
 
         z = f"""create or replace temporary view base_{self.de.YEAR}_temp2 as
                 select *,
-                    case when AGE_NUM_RAW < -1 then null 
-                        when AGE_NUM_RAW > 125 then 125 
-                    else AGE_NUM_RAW 
+                    case when AGE_NUM_RAW < -1 then null
+                        when AGE_NUM_RAW > 125 then 125
+                    else AGE_NUM_RAW
                     end as AGE_NUM
                 from base_{self.de.YEAR}_temp1
             """
@@ -640,7 +639,7 @@ class DE0001BASE(DE):
 
         z = f"""create or replace temporary view base_{self.de.YEAR} as
                 select *,
-                    case when AGE_NUM between -1 and 0 then 1 
+                    case when AGE_NUM between -1 and 0 then 1
                         when AGE_NUM between 1 and 5 then 2
                         when AGE_NUM between 6 and 14 then 3
                         when AGE_NUM between 15 and 18 then 4
@@ -650,7 +649,7 @@ class DE0001BASE(DE):
                         when AGE_NUM between 65 and 74 then 8
                         when AGE_NUM between 75 and 84 then 9
                         when AGE_NUM between 85 and 125 then 10
-                    else null 
+                    else null
                     end as AGE_GRP_FLAG
                 from base_{self.de.YEAR}_temp2
             """

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -176,7 +176,7 @@ class LTH:
                 ,LT_SUD_TAXONOMY_IND as LT_SUD_TXNMY_IND
                 ,nullif(IAP_CONDITION_IND, IAP_CONDITION_IND) as IAP_COND_IND
                 ,nullif(PRIMARY_HIERARCHICAL_CONDITION, PRIMARY_HIERARCHICAL_CONDITION) as PRMRY_HIRCHCL_COND
-                ,to_timestamp('{runner.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,cast(NULL as timestamp) as REC_UPDT_TS
                 ,{ TAF_Closure.var_set_taxo('BLG_PRVDR_NPPES_TXNMY_CD',cond1='8888888888', cond2='9999999999', cond3='000000000X', cond4='999999999X',
                                                 cond5='NONE', cond6='XXXXXXXXXX', cond7='NO TAXONOMY') }

--- a/taf/MCP/MCP03.py
+++ b/taf/MCP/MCP03.py
@@ -6,7 +6,7 @@ class MCP03(MCP):
     """
     Description:  Selection Functions for the T-MSIS MC segments.
     """
-     
+
     def __init__(self, mcp: MCP_Runner):
         super().__init__(mcp)
 
@@ -14,7 +14,7 @@ class MCP03(MCP):
         """
         000-03 location segment
         """
-         
+
         # screen out all but the latest run id
         runlist = ["tms_run_id", "submitting_state", "state_plan_id_num"]
 
@@ -99,9 +99,9 @@ class MCP03(MCP):
 
     def create(self):
         """
-        Create the MCP03 location segment.  
+        Create the MCP03 location segment.
         """
-         
+
         self.process_03_location("MC02_Main_RAW", "MC03_Location")
 
         self.recode_notnull(
@@ -160,14 +160,14 @@ class MCP03(MCP):
 
     def build(self, runner: MCP_Runner):
         """
-        Build the MCP03 location segment.  
+        Build the MCP03 location segment.
         """
-         
+
         z = f"""
                 INSERT INTO {runner.DA_SCHEMA}.taf_mcl
                 SELECT
                     *
-                   ,to_timestamp('{self.mcp.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                   ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                    ,current_timestamp() as REC_UPDT_TS
                 FROM
                     MC03_Location_CNST

--- a/taf/MCP/MCP04.py
+++ b/taf/MCP/MCP04.py
@@ -6,7 +6,7 @@ class MCP04(MCP):
     """
     Description:  Selection Functions for the T-MSIS MC segments
     """
-     
+
     def __init__(self, mcp: MCP_Runner):
         super().__init__(mcp)
 
@@ -14,7 +14,7 @@ class MCP04(MCP):
         """
         000-04 service_area segment
         """
-         
+
         # screen out all but the latest run id
         runlist = ["tms_run_id", "submitting_state", "state_plan_id_num"]
 
@@ -89,9 +89,9 @@ class MCP04(MCP):
 
     def create(self):
         """
-        Create the MCP04 service area segment.  
+        Create the MCP04 service area segment.
         """
-         
+
         self.process_04_service_area("MC02_Main_RAW", "MC04_Service_Area")
 
         # diststyle key distkey(state_plan_id_num)
@@ -118,14 +118,14 @@ class MCP04(MCP):
 
     def build(self, runner: MCP_Runner):
         """
-        Build the MCP04 service area segment.  
+        Build the MCP04 service area segment.
         """
-         
+
         z = f"""
                 INSERT INTO {runner.DA_SCHEMA}.taf_mcs
                 SELECT
                     *
-                   ,to_timestamp('{self.mcp.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                   ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                    ,current_timestamp() as REC_UPDT_TS
                 FROM
                     MC04_Service_Area_CNST

--- a/taf/MCP/MCP06.py
+++ b/taf/MCP/MCP06.py
@@ -7,7 +7,7 @@ class MCP06(MCP):
     """
     Description:  Selection Functions for the T-MSIS MC segments
     """
-     
+
     def __init__(self, mcp: MCP_Runner):
         super().__init__(mcp)
 
@@ -15,7 +15,7 @@ class MCP06(MCP):
         """
         000-06 population segment
         """
-         
+
         # screen out all but the latest run id
         runlist = ["tms_run_id", "submitting_state", "state_plan_id_num"]
 
@@ -90,9 +90,9 @@ class MCP06(MCP):
 
     def create(self):
         """
-        Create the MCP06 population segment.  
+        Create the MCP06 population segment.
         """
-         
+
         self.process_06_population("MC02_Main_RAW", "MC06_Population_RAW")
 
         self.recode_lookup(
@@ -230,14 +230,14 @@ class MCP06(MCP):
 
     def build(self, runner: MCP_Runner):
         """
-        Build the MCP06 population segment.  
+        Build the MCP06 population segment.
         """
-         
+
         z = f"""
                 INSERT INTO {runner.DA_SCHEMA}.taf_mce
                 SELECT
                     *
-                   ,to_timestamp('{self.mcp.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                   ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                    ,current_timestamp() as REC_UPDT_TS
                 FROM
                     MC06_Population

--- a/taf/MCP/MCP07.py
+++ b/taf/MCP/MCP07.py
@@ -439,7 +439,7 @@ class MCP07(MCP):
                 INSERT INTO {runner.DA_SCHEMA}.taf_mcp
                 SELECT
                     { ', '.join(base_col_list) }
-                   ,to_timestamp('{self.mcp.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                   ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                    ,current_timestamp() as REC_UPDT_TS
                 FROM
                     MC02_Base

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -160,7 +160,7 @@ class OTH:
 
                 , cast(nullif(IAP_CONDITION_IND, IAP_CONDITION_IND) as char(6)) as IAP_COND_IND
                 , cast(nullif(PRIMARY_HIERARCHICAL_CONDITION, PRIMARY_HIERARCHICAL_CONDITION) as char(9)) as PRMRY_HIRCHCL_COND
-                ,to_timestamp('{runner.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,cast(NULL as timestamp) as REC_UPDT_TS
                 , { TAF_Closure.fix_old_dates('SRVC_ENDG_DT_DRVD') }
                 , { TAF_Closure.var_set_type2('SRVC_ENDG_DT_CD',0,cond1='1',cond2='2',cond3='3',cond4='4',cond5='5') }

--- a/taf/PRV/PRV03.py
+++ b/taf/PRV/PRV03.py
@@ -347,7 +347,7 @@ class PRV03(PRV):
                     when L.PRVDR_ADR_SRVC_IND=1 and T.SUBMTG_STATE_rcd<>T.ADR_STATE_CD then 1
                     else null
                     end as PRVDR_SRVC_ST_DFRNT_SUBMTG_ST,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
             from Prov03_Location_BSM T
                 left join Prov03_Location_mapt L

--- a/taf/PRV/PRV04.py
+++ b/taf/PRV/PRV04.py
@@ -120,7 +120,7 @@ class PRV04(PRV):
                     LCNS_TYPE_CD,
                     license_or_accreditation_number as LCNS_OR_ACRDTN_NUM,
                     license_issuing_entity_id as LCNS_ISSG_ENT_ID_TXT,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                     from Prov04_Licensing_TYP
                     where LCNS_TYPE_CD is not null

--- a/taf/PRV/PRV05.py
+++ b/taf/PRV/PRV05.py
@@ -120,7 +120,7 @@ class PRV05(PRV):
                     PRVDR_ID_TYPE_CD,
                     cast(prov_identifier as varchar(12)) as PRVDR_ID,
                     prov_identifier_issuing_entity_id as PRVDR_ID_ISSG_ENT_ID_TXT,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                     from Prov05_Identifiers_TYP
                     where PRVDR_ID_TYPE_CD is not null

--- a/taf/PRV/PRV06.py
+++ b/taf/PRV/PRV06.py
@@ -394,7 +394,7 @@ class PRV06(PRV):
                         submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
                         PRVDR_CLSFCTN_TYPE_CD,
                         PRVDR_CLSFCTN_CD,
-                        to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                        from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                         current_timestamp() as REC_UPDT_TS
                         from Prov06_Taxonomies_ALL
                         where PRVDR_CLSFCTN_TYPE_CD is not null and PRVDR_CLSFCTN_CD is not null

--- a/taf/PRV/PRV07.py
+++ b/taf/PRV/PRV07.py
@@ -199,7 +199,7 @@ class PRV07(PRV):
                     PRVDR_MDCD_ENRLMT_MTHD_CD,
                     APLCTN_DT,
                     PRVDR_MDCD_ENRLMT_STUS_CTGRY,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                     from Prov07_Medicaid_CNST
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID
@@ -299,7 +299,7 @@ class PRV07(PRV):
                         T.sud_srvc_prvdr_ind,
                         T.mh_srvc_prvdr_ind,
                         T.emer_srvcs_prvdr_ind,
-                        to_timestamp(cast(M.da_run_id as string), 'yyyyMMddHHmmss') as REC_ADD_TS,
+                        from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                         current_timestamp() as REC_UPDT_TS
                 from Prov02_Main_CNST M
                 left join Prov07_Medicaid_Mapped E

--- a/taf/PRV/PRV08.py
+++ b/taf/PRV/PRV08.py
@@ -97,7 +97,7 @@ class PRV08(PRV):
                     SUBMTG_STATE_CD,
                     submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
                     cast (submitting_state_prov_id_of_affiliated_entity as varchar(12)) as SUBMTG_STATE_AFLTD_PRVDR_ID,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                     from Prov08_Groups
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID

--- a/taf/PRV/PRV09.py
+++ b/taf/PRV/PRV09.py
@@ -127,7 +127,7 @@ class PRV09(PRV):
                     submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
                     AFLTD_PGM_TYPE_CD,
                     affiliated_program_id as AFLTD_PGM_ID,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                     from Prov09_AffPgms_TYP
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID

--- a/taf/PRV/PRV10.py
+++ b/taf/PRV/PRV10.py
@@ -116,7 +116,7 @@ class PRV10(PRV):
                     prov_location_id as PRVDR_LCTN_ID,
                     BED_TYPE_CD,
                     bed_count as BED_CNT,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                 from Prov10_BedType_TYP
                 where BED_TYPE_CD is not null or (bed_count is not null and bed_count<>0)
@@ -249,7 +249,7 @@ class PRV10(PRV):
                     NULL AS ADR_CNTY_CD,
                     NULL AS ADR_BRDR_STATE_IND,
                     NULL AS PRVDR_SRVC_ST_DFRNT_SUBMTG_ST,
-                    to_timestamp('{self.prv.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS,
+                    from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     current_timestamp() as REC_UPDT_TS
                 from
                     loc__g

--- a/taf/RX/RXH.py
+++ b/taf/RX/RXH.py
@@ -97,7 +97,7 @@ class RXH:
                 , { TAF_Closure.var_set_type2('COPAY_WVD_IND', 0, cond1='0', cond2='1') }
                 , cll_cnt
                 , num_cll
-                ,to_timestamp('{runner.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,cast(NULL as timestamp) as REC_UPDT_TS
             from (
                 select


### PR DESCRIPTION
**MACDC-4144 replace all rec add ts variables to use timestamp instead of da run id as its no longer valid**

## What is this?
Due to the change of da_run_id from timestamp derived to databricks job_id the code that is parsing the da_run_id as a timestamp is not valid. It was bad practice to begin with. I'm moved the rec_add_ts (record add timestamp) to use the actual timestamp.

## How would you classify this change (feature, bug, maintenance, etc.)?
bug

## How did I test this (if code change)?

1. Ran databricks jobs successfully.
2. Checked timestamp

## Is there accompanying documentation for this change?
No.

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_