### PR TITLE
MACDC-4276 PROV_DBA_NAME empty string to NULL

### DIFF
--- a/taf/PRV/PRV02.py
+++ b/taf/PRV/PRV02.py
@@ -280,8 +280,8 @@ class PRV02(PRV):
                     submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
                     REG_FLAG,
                     case
-                      when nullif(trim(TRAILING FROM prov_doing_business_as_name),'')='888888888888888888888888888888888888888888888888888888888888888' then ''
-                      when nullif(trim(TRAILING FROM prov_doing_business_as_name),'')='99999999999999999999999999999999999999999999999999' then ''
+                      when nullif(trim(TRAILING FROM prov_doing_business_as_name),'')='888888888888888888888888888888888888888888888888888888888888888' then NULL
+                      when nullif(trim(TRAILING FROM prov_doing_business_as_name),'')='99999999999999999999999999999999999999999999999999' then NULL
                       else { TAF_Closure.upper_case('prov_doing_business_as_name') } 
                     end as PRVDR_DBA_NAME,
                     { TAF_Closure.upper_case('prov_legal_name') } as PRVDR_LGL_NAME,


### PR DESCRIPTION
## What is this?
We are changes some values that are meant to mean missing (long strings of 8s or 9s) in PRVDR_DBA_NAME on the PRV base file from an empty string to NULL values.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I created a Databricks Notebook to compare changes to the PRV02 segment (specifically the Prov02_Main_CNST view). The count of NULL PROV_DBA_NAME values was compared to (and matched) the corresponding production PRV run.

https://databricks-val-data.macbisdw.cmscloud.local/#notebook/644690

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-4276

## Issues Encountered

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_