### PR TITLE
MACDC-4376 Change REC_UPDT_TS to be null on insert

### DIFF
--- a/taf/APL/BASE.py
+++ b/taf/APL/BASE.py
@@ -461,7 +461,7 @@ class BASE(APL):
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM base_{self.year}_final
             """
         self.apl.append(type(self).__name__, z)

--- a/taf/APL/ENRLMT.py
+++ b/taf/APL/ENRLMT.py
@@ -69,7 +69,7 @@ class ENRLMT(APL):
         #         ,MC_ENRLMT_FLAG_11
         #         ,MC_ENRLMT_FLAG_12
         #         ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
-        #         ,current_timestamp() as REC_UPDT_TS
+        #         ,cast(NULL as timestamp) as REC_UPDT_TS
         #     from enrlmt_pl_{self.year}"""
 
         z = f"""
@@ -78,7 +78,7 @@ class ENRLMT(APL):
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM enrlmt_pl_{self.year}
             """
 

--- a/taf/APL/LCTN.py
+++ b/taf/APL/LCTN.py
@@ -91,7 +91,7 @@ class LCTN(APL):
             #     ,MC_LCTN_FLAG_11
             #     ,MC_LCTN_FLAG_12
             #     ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
-            #     ,current_timestamp() as REC_UPDT_TS
+            #     ,cast(NULL as timestamp) as REC_UPDT_TS
             # from lctn_pl_{self.year}"""
 
         z = f"""
@@ -100,7 +100,7 @@ class LCTN(APL):
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM lctn_pl_{self.year}
             """            
         self.apl.append(type(self).__name__, z)

--- a/taf/APL/OA.py
+++ b/taf/APL/OA.py
@@ -201,7 +201,7 @@ class OA(APL):
         #         ,OPRTG_AUTHRTY_FLAG_11
         #         ,OPRTG_AUTHRTY_FLAG_12
         #         ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
-        #         ,current_timestamp() as REC_UPDT_TS
+        #         ,cast(NULL as timestamp) as REC_UPDT_TS
         #     from OpAuth1
         #     """
 
@@ -211,7 +211,7 @@ class OA(APL):
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM OpAuth1
             """
             

--- a/taf/APL/SAREA.py
+++ b/taf/APL/SAREA.py
@@ -78,7 +78,7 @@ class SAREA(APL):
         #         ,MC_SAREA_LCTN_FLAG_11
         #         ,MC_SAREA_LCTN_FLAG_12
         #         ,to_timestamp('{self.apl.DA_RUN_ID}', 'yyyyMMddHHmmss') as REC_ADD_TS
-        #         ,current_timestamp() as REC_UPDT_TS
+        #         ,cast(NULL as timestamp) as REC_UPDT_TS
         #     from sarea_pl_{self.year}"""
 
         z = f"""
@@ -87,7 +87,7 @@ class SAREA(APL):
                  {self.table_id_cols()}
                 ,{",".join(self.basecols)}
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM sarea_pl_{self.year}
             """            
 

--- a/taf/APR/BASE.py
+++ b/taf/APR/BASE.py
@@ -235,7 +235,7 @@ class BASE(APR):
                  { self.table_id_cols() }
                 ,{ ','.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM base_{self.year}_final"""
 
         self.apr.append(type(self).__name__, z)

--- a/taf/APR/BED.py
+++ b/taf/APR/BED.py
@@ -67,7 +67,7 @@ class BED(APR):
                 {self.table_id_cols(loctype=2)}
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM bed_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/ENR.py
+++ b/taf/APR/ENR.py
@@ -73,7 +73,7 @@ class ENR(APR):
                 {self.table_id_cols()}
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM enrlmt_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/GRP.py
+++ b/taf/APR/GRP.py
@@ -63,7 +63,7 @@ class GRP(APR):
                 {self.table_id_cols()}
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM grp_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/IDT.py
+++ b/taf/APR/IDT.py
@@ -167,7 +167,7 @@ class IDT(APR):
                 {self.table_id_cols(loctype=2)}
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM id_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/LIC.py
+++ b/taf/APR/LIC.py
@@ -70,7 +70,7 @@ class LIC(APR):
                 {self.table_id_cols(loctype=2)}
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM lcns_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/LOC.py
+++ b/taf/APR/LOC.py
@@ -89,7 +89,7 @@ class LOC(APR):
                     {self.table_id_cols(loctype=1)}
                     ,{ ', '.join(basecols) }
                     ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                    ,current_timestamp() as REC_UPDT_TS
+                    ,cast(NULL as timestamp) as REC_UPDT_TS
                 FROM lctn_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/PGM.py
+++ b/taf/APR/PGM.py
@@ -65,7 +65,7 @@ class PGM(APR):
                  { self.table_id_cols() }
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM pgm_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/APR/TAX.py
+++ b/taf/APR/TAX.py
@@ -66,7 +66,7 @@ class TAX(APR):
                 {self.table_id_cols()}
                 ,{ ', '.join(basecols) }
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM txnmy_pr_{self.year}"""
         self.apr.append(type(self).__name__, z)
 

--- a/taf/DE/DE.py
+++ b/taf/DE/DE.py
@@ -351,7 +351,7 @@ class DE(TAF):
         if as_select is False:
             z += f"""
                 ,current_timestamp() as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
                 ,{self.de.DA_RUN_ID} as DA_RUN_ID
                 ,SUBMTG_STATE_CD
                 """

--- a/taf/DE/DE0001BASE.py
+++ b/taf/DE/DE0001BASE.py
@@ -794,7 +794,7 @@ class DE0001BASE(DE):
                 ,MSIS_IDENT_NUM_comb
                 {self.basecols()}
                 ,current_timestamp() as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
                 ,{self.de.DA_RUN_ID} as DA_RUN_ID
                 ,SUBMTG_STATE_CD_comb
 

--- a/taf/MCP/MCP03.py
+++ b/taf/MCP/MCP03.py
@@ -168,7 +168,7 @@ class MCP03(MCP):
                 SELECT
                     *
                    ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                   ,current_timestamp() as REC_UPDT_TS
+                   ,cast(NULL as timestamp) as REC_UPDT_TS
                 FROM
                     MC03_Location_CNST
         """

--- a/taf/MCP/MCP04.py
+++ b/taf/MCP/MCP04.py
@@ -126,7 +126,7 @@ class MCP04(MCP):
                 SELECT
                     *
                    ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                   ,current_timestamp() as REC_UPDT_TS
+                   ,cast(NULL as timestamp) as REC_UPDT_TS
                 FROM
                     MC04_Service_Area_CNST
         """

--- a/taf/MCP/MCP06.py
+++ b/taf/MCP/MCP06.py
@@ -238,7 +238,7 @@ class MCP06(MCP):
                 SELECT
                     *
                    ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                   ,current_timestamp() as REC_UPDT_TS
+                   ,cast(NULL as timestamp) as REC_UPDT_TS
                 FROM
                     MC06_Population
         """

--- a/taf/MCP/MCP07.py
+++ b/taf/MCP/MCP07.py
@@ -440,7 +440,7 @@ class MCP07(MCP):
                 SELECT
                     { ', '.join(base_col_list) }
                    ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                   ,current_timestamp() as REC_UPDT_TS
+                   ,cast(NULL as timestamp) as REC_UPDT_TS
                 FROM
                     MC02_Base
         """

--- a/taf/PRV/PRV03.py
+++ b/taf/PRV/PRV03.py
@@ -348,7 +348,7 @@ class PRV03(PRV):
                     else null
                     end as PRVDR_SRVC_ST_DFRNT_SUBMTG_ST,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
             from Prov03_Location_BSM T
                 left join Prov03_Location_mapt L
                     on T.{keyl}=L.{keyl}

--- a/taf/PRV/PRV04.py
+++ b/taf/PRV/PRV04.py
@@ -121,7 +121,7 @@ class PRV04(PRV):
                     license_or_accreditation_number as LCNS_OR_ACRDTN_NUM,
                     license_issuing_entity_id as LCNS_ISSG_ENT_ID_TXT,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                     from Prov04_Licensing_TYP
                     where LCNS_TYPE_CD is not null
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID, PRVDR_LCTN_ID

--- a/taf/PRV/PRV05.py
+++ b/taf/PRV/PRV05.py
@@ -121,7 +121,7 @@ class PRV05(PRV):
                     cast(prov_identifier as varchar(12)) as PRVDR_ID,
                     prov_identifier_issuing_entity_id as PRVDR_ID_ISSG_ENT_ID_TXT,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                     from Prov05_Identifiers_TYP
                     where PRVDR_ID_TYPE_CD is not null
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID, PRVDR_LCTN_ID

--- a/taf/PRV/PRV06.py
+++ b/taf/PRV/PRV06.py
@@ -395,7 +395,7 @@ class PRV06(PRV):
                         PRVDR_CLSFCTN_TYPE_CD,
                         PRVDR_CLSFCTN_CD,
                         from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                        current_timestamp() as REC_UPDT_TS
+                        cast(NULL as timestamp) as REC_UPDT_TS
                         from Prov06_Taxonomies_ALL
                         where PRVDR_CLSFCTN_TYPE_CD is not null and PRVDR_CLSFCTN_CD is not null
                 order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID

--- a/taf/PRV/PRV07.py
+++ b/taf/PRV/PRV07.py
@@ -200,7 +200,7 @@ class PRV07(PRV):
                     APLCTN_DT,
                     PRVDR_MDCD_ENRLMT_STUS_CTGRY,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                     from Prov07_Medicaid_CNST
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID
             """
@@ -300,7 +300,7 @@ class PRV07(PRV):
                         T.mh_srvc_prvdr_ind,
                         T.emer_srvcs_prvdr_ind,
                         from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                        current_timestamp() as REC_UPDT_TS
+                        cast(NULL as timestamp) as REC_UPDT_TS
                 from Prov02_Main_CNST M
                 left join Prov07_Medicaid_Mapped E
                     on {self.write_equalkeys(self.srtlist, 'M', 'E')}

--- a/taf/PRV/PRV08.py
+++ b/taf/PRV/PRV08.py
@@ -98,7 +98,7 @@ class PRV08(PRV):
                     submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
                     cast (submitting_state_prov_id_of_affiliated_entity as varchar(12)) as SUBMTG_STATE_AFLTD_PRVDR_ID,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                     from Prov08_Groups
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID
             """

--- a/taf/PRV/PRV09.py
+++ b/taf/PRV/PRV09.py
@@ -128,7 +128,7 @@ class PRV09(PRV):
                     AFLTD_PGM_TYPE_CD,
                     affiliated_program_id as AFLTD_PGM_ID,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                     from Prov09_AffPgms_TYP
             order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID
             """

--- a/taf/PRV/PRV10.py
+++ b/taf/PRV/PRV10.py
@@ -117,7 +117,7 @@ class PRV10(PRV):
                     BED_TYPE_CD,
                     bed_count as BED_CNT,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                 from Prov10_BedType_TYP
                 where BED_TYPE_CD is not null or (bed_count is not null and bed_count<>0)
                 order by TMSIS_RUN_ID, SUBMTG_STATE_CD, SUBMTG_STATE_PRVDR_ID, PRVDR_LCTN_ID
@@ -250,7 +250,7 @@ class PRV10(PRV):
                     NULL AS ADR_BRDR_STATE_IND,
                     NULL AS PRVDR_SRVC_ST_DFRNT_SUBMTG_ST,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
-                    current_timestamp() as REC_UPDT_TS
+                    cast(NULL as timestamp) as REC_UPDT_TS
                 from
                     loc__g
         """

--- a/taf/UP/BASE_FNL.py
+++ b/taf/UP/BASE_FNL.py
@@ -156,7 +156,7 @@ class BASE_FNL(UP):
                      { self.table_id_cols() }
                     ,{",".join(self.basecols)}
                     ,current_timestamp() as REC_ADD_TS
-                    ,current_timestamp() as REC_UPDT_TS
+                    ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM base_fnl_{self.year}
         """
         self.up.append(type(self).__name__, z)

--- a/taf/UP/TOP.py
+++ b/taf/UP/TOP.py
@@ -86,7 +86,7 @@ class TOP(UP):
                 ,CLM_TOT
                 ,SUM_TOT_MDCD_PD
                 ,current_timestamp() as REC_ADD_TS
-                ,current_timestamp() as REC_UPDT_TS
+                ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM top_fnl_{self.year}
         """
         self.up.append(type(self).__name__, z)


### PR DESCRIPTION
## What is this?

This changes REC_UPDT_TS to null for rows when a record is inserted, but not updated. Only metadata tables make use of this column.

## How would you classify this change (feature, bug, maintenance, etc.)?

bug

## How did I test this (if code change)?

## Is there accompanying documentation for this change?

## Issues Encountered

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [ ] Is the issue number and a short description in the subject line?
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_