### PR TITLE
Fix incorrect NPI column name to NPPES

### DIFF
--- a/taf/TAF_Grouper.py
+++ b/taf/TAF_Grouper.py
@@ -629,7 +629,7 @@ class TAF_Grouper:
                     { self.select_taxonomy_inner(TAXONOMY, filetyp) }
                 from
                     {clm_tbl} b
-                    left join nppes_npi nppes on nppes.NPI=b.BLG_PRVDR_NPI_NUM
+                    left join nppes_npi nppes on nppes.prvdr_npi=b.BLG_PRVDR_NPI_NUM
             ) as a
 
             left join ccs_dx ccs_dx on ccs_dx.icd_10_cm_cd=a.DGNS_1_CD


### PR DESCRIPTION
## What is this?
This is a bug fix to change the source of TAF input data from a static S3 bucket used during development to DataConnect for the National Plan and Provider Enumeration System (NPPES) data. Claim and Provider file types are impacted by this change.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug fix

## How did I test this (if code change)?
https://databricks-val-data.macbisdw.cmscloud.local/#notebook/1091477/command/1091496

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-4247

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_