### PR TITLE
MACDC-4777 Corrected State Specific RegExps

### DIFF
--- a/taf/APL/APL.py
+++ b/taf/APL/APL.py
@@ -75,8 +75,7 @@ class APL(TAF):
                     WHERE upper(fil_type) = '{file}'
                         AND sucsfl_ind = 1
                         AND substring(job_parms_txt, 1, 4) = '{inyear}'
-                        AND charindex('submtg_state_cd
-                in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
+                        AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) = 0
                     )
                 GROUP BY {file}_fil_dt
         """
@@ -92,13 +91,13 @@ class APL(TAF):
                     ,max(da_run_id) AS da_run_id
                 FROM (
                     SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS {file}_fil_dt
-                        ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
+                        ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{{2}})') AS submtg_state_cd
                         ,da_run_id
                     FROM {self.apl.DA_SCHEMA}.job_cntl_parms
                     WHERE upper(fil_type) = '{file}'
                         AND sucsfl_ind = 1
                         AND substring(job_parms_txt, 1, 4) = '{inyear}'
-                        AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
+                        AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) > 0
                     )
                 GROUP BY {file}_fil_dt
                     ,submtg_state_cd

--- a/taf/APR/APR.py
+++ b/taf/APR/APR.py
@@ -87,8 +87,7 @@ class APR(TAF):
                     WHERE upper(fil_type) = '{file}'
                         AND sucsfl_ind = 1
                         AND substring(job_parms_txt, 1, 4) = '{inyear}'
-                        AND charindex('submtg_state_cd
-                in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
+                        AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) = 0
                     )
                 GROUP BY {file}_fil_dt
         """
@@ -104,13 +103,13 @@ class APR(TAF):
                     ,max(da_run_id) AS da_run_id
                 FROM (
                     SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS {file}_fil_dt
-                        ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
+                        ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{{2}})') AS submtg_state_cd
                         ,da_run_id
                     FROM {self.apr.DA_SCHEMA}.job_cntl_parms
                     WHERE upper(fil_type) = '{file}'
                         AND sucsfl_ind = 1
                         AND substring(job_parms_txt, 1, 4) = '{inyear}'
-                        AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
+                        AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) > 0
                     )
                 GROUP BY {file}_fil_dt
                     ,submtg_state_cd

--- a/taf/DE/DE.py
+++ b/taf/DE/DE.py
@@ -848,7 +848,7 @@ class DE(TAF):
         """
 
         z += f"""
-                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
+                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) = 0
                 )
 
             GROUP BY {file}_fil_dt
@@ -866,7 +866,7 @@ class DE(TAF):
                 ,max(da_run_id) AS da_run_id
             FROM (
                 SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS {file}_fil_dt
-                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
+                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{{2}})') AS submtg_state_cd
                     ,da_run_id
                 FROM {self.de.DA_SCHEMA_DC}.job_cntl_parms
                 WHERE upper(substring(fil_type, 2)) = "{file}"
@@ -875,7 +875,7 @@ class DE(TAF):
         """
 
         z += f"""
-                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
+                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) > 0
                 )
 
             GROUP BY {file}_fil_dt

--- a/taf/UP/UP.py
+++ b/taf/UP/UP.py
@@ -328,7 +328,7 @@ class UP(TAF):
             """
 
         z += f"""
-                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
+                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) = 0
                 )
 
             GROUP BY {file}_fil_dt
@@ -346,7 +346,7 @@ class UP(TAF):
                 ,max(da_run_id) AS da_run_id
             FROM (
                 SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS {file}_fil_dt
-                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
+                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{{2}})') AS submtg_state_cd
                     ,da_run_id
                 FROM {self.up.DA_SCHEMA_DC}.job_cntl_parms
                 WHERE upper(substring(fil_type, 2)) = "{file}"
@@ -373,7 +373,7 @@ class UP(TAF):
             """
 
         z += f"""
-                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
+                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\\s+', ' ')) > 0
                 )
 
             GROUP BY {file}_fil_dt


### PR DESCRIPTION
## What is this?
This is a bug fix to correct regular expressions responsible for identifying state-specific runs when determining high values for DA_RUN_IDs used as inputs to TAF annual file types.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I took SQL generated from the TAF library and reviewed within a Databricks Notebook and production Redshift in order to rule out any differences with regular expression behaviors. Then, I ran changes for North Carolina and confirmed state specific output appeared in corresponding max run ID views.

https://databricks-val-data.macbisdw.cmscloud.local/#notebook/3638026

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-4777

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_