### PR TITLE
MACDC-5023 Wrong input for some TMSIS tables

### DIFF
--- a/taf/BSF/ELG.py
+++ b/taf/BSF/ELG.py
@@ -40,7 +40,7 @@ class ELG():
                         , upper(a.MSIS_IDENT_NUM) as MSIS_IDENT_NUM
                         , a.TMSIS_RPTG_PRD
                     from
-                        {self.bsf.DA_SCHEMA}.{self._2x_segment}_temp_taf as a
+                        {self.bsf.DA_SCHEMA}.{self._2x_segment} as a
 
                     left join
                         state_submsn_type s

--- a/taf/IP/IP.py
+++ b/taf/IP/IP.py
@@ -43,7 +43,7 @@ class IP(TAF):
                 { IP_Metadata.selectDataElements(tab_no, 'a') }
 
             from
-                {DA_SCHEMA}.{_2x_segment}_TEMP_TAF A
+                {DA_SCHEMA}.{_2x_segment} A
 
             where
                 a.TMSIS_ACTV_IND = 1

--- a/taf/LT/LT.py
+++ b/taf/LT/LT.py
@@ -40,7 +40,7 @@ class LT(TAF):
                 { LT_Metadata.selectDataElements(tab_no, 'a') }
 
             from
-                {DA_SCHEMA}.{_2x_segment}_TEMP_TAF A
+                {DA_SCHEMA}.{_2x_segment} A
 
             where
                 a.TMSIS_ACTV_IND = 1

--- a/taf/OT/OT.py
+++ b/taf/OT/OT.py
@@ -50,7 +50,7 @@ class OT(TAF):
                 { OT_Metadata.selectDataElements(tab_no, 'a') }
 
             from
-                {DA_SCHEMA}.{_2x_segment}_TEMP_TAF A
+                {DA_SCHEMA}.{_2x_segment} A
 
             where
                 a.TMSIS_ACTV_IND = 1

--- a/taf/RX/RX.py
+++ b/taf/RX/RX.py
@@ -35,7 +35,7 @@ class RX(TAF):
                 { RX_Metadata.selectDataElements(tab_no, 'a') }
 
             from
-                {DA_SCHEMA}.{_2x_segment}_TEMP_TAF A
+                {DA_SCHEMA}.{_2x_segment} A
 
             where
                 a.TMSIS_ACTV_IND = 1

--- a/test/integration_testing/BSF/test_BSF_Runner.py
+++ b/test/integration_testing/BSF/test_BSF_Runner.py
@@ -1,7 +1,131 @@
 from taf.BSF.BSF_Runner import BSF_Runner
 
-bsf = BSF_Runner('2021-11-30', False)
+bsf = BSF_Runner(
+    da_schema="TAF_PYTHON",
+    reporting_period="2022-02-28",
+    state_code="'05'",
+    run_id="'4863'",
+    job_id="'99999'",
+)
 bsf.init()
 
-# bsf.view_plan()
-bsf.write('BSF')
+print(bsf.view_plan())
+
+
+# -----------------------------------------------------------------------------
+# CC0 1.0 Universal
+
+# Statement of Purpose
+
+# The laws of most jurisdictions throughout the world automatically confer
+# exclusive Copyright and Related Rights (defined below) upon the creator and
+# subsequent owner(s) (each and all, an "owner") of an original work of
+# authorship and/or a database (each, a "Work").
+
+# Certain owners wish to permanently relinquish those rights to a Work for the
+# purpose of contributing to a commons of creative, cultural and scientific
+# works ("Commons") that the public can reliably and without fear of later
+# claims of infringement build upon, modify, incorporate in other works, reuse
+# and redistribute as freely as possible in any form whatsoever and for any
+# purposes, including without limitation commercial purposes. These owners may
+# contribute to the Commons to promote the ideal of a free culture and the
+# further production of creative, cultural and scientific works, or to gain
+# reputation or greater distribution for their Work in part through the use and
+# efforts of others.
+
+# For these and/or other purposes and motivations, and without any expectation
+# of additional consideration or compensation, the person associating CC0 with a
+# Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+# and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+# and publicly distribute the Work under its terms, with knowledge of his or her
+# Copyright and Related Rights in the Work and the meaning and intended legal
+# effect of CC0 on those rights.
+
+# 1. Copyright and Related Rights. A Work made available under CC0 may be
+# protected by copyright and related or neighboring rights ("Copyright and
+# Related Rights"). Copyright and Related Rights include, but are not limited
+# to, the following:
+
+#   i. the right to reproduce, adapt, distribute, perform, display, communicate,
+#   and translate a Work
+
+#   ii. moral rights retained by the original author(s) and/or performer(s)
+
+#   iii. publicity and privacy rights pertaining to a person's image or likeness
+#   depicted in a Work
+
+#   iv. rights protecting against unfair competition in regards to a Work,
+#   subject to the limitations in paragraph 4(a), below
+
+#   v. rights protecting the extraction, dissemination, use and reuse of data in
+#   a Work
+
+#   vi. database rights (such as those arising under Directive 96/9/EC of the
+#   European Parliament and of the Council of 11 March 1996 on the legal
+#   protection of databases, and under any national implementation thereof,
+#   including any amended or successor version of such directive) and
+
+#   vii. other similar, equivalent or corresponding rights throughout the world
+#   based on applicable law or treaty, and any national implementations thereof.
+
+# 2. Waiver. To the greatest extent permitted by, but not in contravention of,
+# applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+# unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+# and Related Rights and associated claims and causes of action, whether now
+# known or unknown (including existing as well as future claims and causes of
+# action), in the Work (i) in all territories worldwide, (ii) for the maximum
+# duration provided by applicable law or treaty (including future time
+# extensions), (iii) in any current or future medium and for any number of
+# copies, and (iv) for any purpose whatsoever, including without limitation
+# commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+# the Waiver for the benefit of each member of the public at large and to the
+# detriment of Affirmer's heirs and successors, fully intending that such Waiver
+# shall not be subject to revocation, rescission, cancellation, termination, or
+# any other legal or equitable action to disrupt the quiet enjoyment of the Work
+# by the public as contemplated by Affirmer's express Statement of Purpose.
+
+# 3. Public License Fallback. Should any part of the Waiver for any reason be
+# judged legally invalid or ineffective under applicable law, then the Waiver
+# shall be preserved to the maximum extent permitted taking into account
+# Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+# is so judged Affirmer hereby grants to each affected person a royalty-free,
+# non transferable, non sublicensable, non exclusive, irrevocable and
+# unconditional license to exercise Affirmer's Copyright and Related Rights in
+# the Work (i) in all territories worldwide, (ii) for the maximum duration
+# provided by applicable law or treaty (including future time extensions), (iii)
+# in any current or future medium and for any number of copies, and (iv) for any
+# purpose whatsoever, including without limitation commercial, advertising or
+# promotional purposes (the "License"). The License shall be deemed effective as
+# of the date CC0 was applied by Affirmer to the Work. Should any part of the
+# License for any reason be judged legally invalid or ineffective under
+# applicable law, such partial invalidity or ineffectiveness shall not
+# invalidate the remainder of the License, and in such case Affirmer hereby
+# affirms that he or she will not (i) exercise any of his or her remaining
+# Copyright and Related Rights in the Work or (ii) assert any associated claims
+# and causes of action with respect to the Work, in either case contrary to
+# Affirmer's express Statement of Purpose.
+
+# 4. Limitations and Disclaimers.
+
+#   a. No trademark or patent rights held by Affirmer are waived, abandoned,
+#   surrendered, licensed or otherwise affected by this document.
+
+#   b. Affirmer offers the Work as-is and makes no representations or warranties
+#   of any kind concerning the Work, express, implied, statutory or otherwise,
+#   including without limitation warranties of title, merchantability, fitness
+#   for a particular purpose, non infringement, or the absence of latent or
+#   other defects, accuracy, or the present or absence of errors, whether or not
+#   discoverable, all to the greatest extent permissible under applicable law.
+
+#   c. Affirmer disclaims responsibility for clearing rights of other persons
+#   that may apply to the Work or any use thereof, including without limitation
+#   any person's Copyright and Related Rights in the Work. Further, Affirmer
+#   disclaims responsibility for obtaining any necessary consents, permissions
+#   or other rights required for any use of the Work.
+
+#   d. Affirmer understands and acknowledges that Creative Commons is not a
+#   party to this document and has no duty or obligation with respect to this
+#   CC0 or use of the Work.
+
+# For more information, please see
+# <http://creativecommons.org/publicdomain/zero/1.0/>

--- a/test/integration_testing/LT/test_LT_Runner.py
+++ b/test/integration_testing/LT/test_LT_Runner.py
@@ -1,15 +1,15 @@
-from taf.IP.IP_Runner import IP_Runner
+from taf.LT.LT_Runner import LT_Runner
 
-ip = IP_Runner(
+lt = LT_Runner(
     da_schema="TAF_PYTHON",
     reporting_period="2022-02-28",
     state_code="'05'",
     run_id="'4863'",
     job_id="'99999'",
 )
-ip.init()
+lt.init()
 
-ip.view_plan()
+lt.view_plan()
 
 
 # -----------------------------------------------------------------------------

--- a/test/integration_testing/OT/test_OT_Runner.py
+++ b/test/integration_testing/OT/test_OT_Runner.py
@@ -1,15 +1,15 @@
-from taf.IP.IP_Runner import IP_Runner
+from taf.OT.OT_Runner import OT_Runner
 
-ip = IP_Runner(
+ot = OT_Runner(
     da_schema="TAF_PYTHON",
     reporting_period="2022-02-28",
     state_code="'05'",
     run_id="'4863'",
     job_id="'99999'",
 )
-ip.init()
+ot.init()
 
-ip.view_plan()
+ot.view_plan()
 
 
 # -----------------------------------------------------------------------------

--- a/test/integration_testing/RX/test_RX_Runner.py
+++ b/test/integration_testing/RX/test_RX_Runner.py
@@ -1,15 +1,15 @@
-from taf.IP.IP_Runner import IP_Runner
+from taf.RX.RX_Runner import RX_Runner
 
-ip = IP_Runner(
+rx = RX_Runner(
     da_schema="TAF_PYTHON",
     reporting_period="2022-02-28",
     state_code="'05'",
     run_id="'4863'",
     job_id="'99999'",
 )
-ip.init()
+rx.init()
 
-ip.view_plan()
+rx.view_plan()
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What is this?
This is a bug fix to read T-MSIS data from SAS views defined in the TMSIS Databricks schema. Currently, the process references view definitions in the TAF_PYTHON Databricks schema for some source tables.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug fix

## How did I test this (if code change)?
I utilized the test programs committed on this branch (bb65d1d) to generate the SQL executed to create TAF, wrote to text files (dbfs:/FileStore/shared_uploads/C1KB/taf/MACDC_5023) and searched with regular expressions for "TEMP_TAF" as well as "TMSIS" to review target tables.

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5023

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_