### PR TITLE
MACDC-4784-last-best-variables-on-the-de-record-not-matching-when-current-year-has-null-values-but-previous-year-has-non-null

### DIFF
--- a/taf/TAF_Runner.py
+++ b/taf/TAF_Runner.py
@@ -637,7 +637,7 @@ class TAF_Runner():
         Helper function to prepend segments to the query plan.
         """
 
-        self.preplan.append(z)
+        self.preplan.append(z + ";")
 
     def append(self, segment: str, z: str):
         """
@@ -740,34 +740,36 @@ class TAF_Runner():
         spark.sql(self.ssn_ind())
 
         self.logger.info('Creating TAF Views...')
-
+        self.logger.info('\trunning preplan...')
         for chain in self.preplan:
-            self.logger.info('\tpreplan...')
-            for z in chain:
-                # self.logger.info('\n'.join(z.split('\n')[0:2]))
+            # self.logger.debug(chain)
+            segment: str = chain.split(";")[0]
+            # self.logger.info(segment)
+            if segment.upper().find("CREATE") >= 0:
+                vs = segment.split()[0:6]
+            elif segment.upper().find("INSERT") >= 0:
+                vs = segment.split()[0:3]
+            else:
+                vs = ""
 
-                v = '\n'.join(z.split('\n')[0:2])
-                vs = v.split()
+            v = " ".join(vs)
+            self.logger.info(v)
 
-                if len(vs) >= 5:
-                    print('\t\t' + vs[5])
+            spark.sql(chain)
 
-                # self.logger.info('\t\t' + v.split()[5])
-
-                spark.sql(z)
-
+        self.logger.info("-- BEGIN SEGMENTS --")
         for segment, chain in self.plan.items():
             self.logger.info('\t' + segment + '...')
             for z in chain:
-                # self.logger.info('\n'.join(z.split('\n')[0:2]))
+                self.logger.debug(z)
+                self.logger.info('\n'.join(z.split('\n')[0:2]))
 
                 v = '\n'.join(z.split('\n')[0:2])
                 vs = v.split()
 
                 if len(vs) >= 5:
                     print('\t\t' + vs[5])
-
-                # self.logger.info('\t\t' + v.split()[5])
+                    self.logger.info('\t\t' + v.split()[5])
 
                 spark.sql(z)
 


### PR DESCRIPTION
## What is this?
corrected logging & display of preplan and segment processing

## How would you classify this change (feature, bug, maintenance, etc.)?
maintenance fix

## How did I test this (if code change)?
Runner Notebooks and User provided notebook

## Is there accompanying documentation for this change?
No

## Issues Encountered

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_