### PR TITLE
MACDC-5365 Incorrect Timestamp values for TAF files

### DIFF
--- a/.databricks/notebooks/flat_files/Create TAF Flat Files.py
+++ b/.databricks/notebooks/flat_files/Create TAF Flat Files.py
@@ -108,7 +108,7 @@ dt = datetime.now()
 
 
 fdate = dt.strftime("%y%m%d")
-ftime = dt.strftime("%H%M%S%f")[0:8]
+ftime = dt.strftime("%H%M%S%f")[0:7]
 
 
 # COMMAND ----------


### PR DESCRIPTION
## What is this?
This is a bug fix to ensure that our TAF file names are compliant with the [shared CMS EFT service's standards](https://tmsis2.atlassian.net/wiki/spaces/DEV/pages/856130293/TAF+-+Knowledge+base). In summary, we must shorten the timestamp to seven bits from eight.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I made a change to the corresponding [Databricks Notebook](https://databricks-val-data.macbisdw.cmscloud.local/?#notebook/3660864/command/3660871) and updated the corresponding Python program (Create TAF Flat Files.py) that's committed to this branch to see the file diff.

The portion of code responsible for the timestamp portion of the TAF file name was ran in this [Databricks Notebook](https://databricks-val-data.macbisdw.cmscloud.local/?#notebook/3676977) and print statements were used to visually confirm timestamps changed to seven bits.

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5365

## Issues Encountered
N/A

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_