### PR TITLE
MACDC-5655 Add upper flag to procedure modifiers

### DIFF
--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -47,7 +47,7 @@ class OTL:
                 , { TAF_Closure.var_set_fillpr('PRCDR_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
                 , { TAF_Closure.fix_old_dates('PRCDR_CD_DT') }
                 , { TAF_Closure.var_set_proc('PRCDR_CD_IND') }
-                , { TAF_Closure.var_set_type1('PRCDR_1_MDFR_CD', lpad=2) }
+                , { TAF_Closure.var_set_type1('PRCDR_1_MDFR_CD', upper=True, lpad=2) }
                 , case when lpad(IMNZTN_TYPE_CD, 2, '0') = '88' then NULL
                     else { TAF_Closure.var_set_type5('IMNZTN_type_cd', lpad=2, lowerbound=0, upperbound=29, multiple_condition='YES') }
                 , { TAF_Closure.var_set_type6('BILL_AMT', cond1='888888888.88', cond2='9999999999.99', cond3='999999.99', cond4='999999') }
@@ -81,9 +81,9 @@ class OTL:
                     else NULL end as XXI_SRVC_CTGRY_CD
                 , { TAF_Closure.var_set_type1('STATE_NOTN_TXT') }
                 , { TAF_Closure.var_set_fills('NDC_CD', cond1='0', cond2='8', cond3='9', cond4='#', spaces=True) }
-                , { TAF_Closure.var_set_type1('PRCDR_2_MDFR_CD', lpad=2) }
-                , { TAF_Closure.var_set_type1('PRCDR_3_MDFR_CD', lpad=2) }
-                , { TAF_Closure.var_set_type1('PRCDR_4_MDFR_CD', lpad=2) }
+                , { TAF_Closure.var_set_type1('PRCDR_2_MDFR_CD', upper=True, lpad=2) }
+                , { TAF_Closure.var_set_type1('PRCDR_3_MDFR_CD', upper=True, lpad=2) }
+                , { TAF_Closure.var_set_type1('PRCDR_4_MDFR_CD', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type3('HCPCS_RATE', cond1='0.0000000000', cond2='0.000000000000', spaces=False) }
                 , { TAF_Closure.var_set_type2('SELF_DRCTN_TYPE_CD', 3, cond1='000', cond2='001', cond3='002', cond4='003') }
                 , { TAF_Closure.var_set_type1('PRE_AUTHRZTN_NUM') }


### PR DESCRIPTION
## What is this?
This is a fix to write procedure code modifiers as upper case (opposed to passing through what is in T-MSIS claim lines) to the TAF Outpatient/Other TOC claim line file type. The functionality was already in the library, so we just had to add a flag to the `var_set_type1` definition for impacted columns.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I ran the `OT Runner` Python program locally and compared generated SQL to confirm the only difference was passing procedure code modifiers to the `upper` SQL function. The `OTL` view was changed.

[https://databricks-val-data.macbisdw.cmscloud.local/#notebook/3693295/command/3693298](Notebook)


## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5655

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_