### PR TITLE
MACDC-5859 Fix default date handling

### DIFF
--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -38,21 +38,16 @@ class LTH:
                 , { TAF_Closure.var_set_rsn('ADJSTMT_RSN_CD') }
                 , case
                     when (SRVC_BGNNG_DT < '1600-01-01') then '1599-12-31'
-                    when 'SRVC_BGNNG_DT' IS NULL then to_date('1960-01-01')
-                    else SRVC_BGNNG_DT
+                    else nullif(SRVC_BGNNG_DT, '1960-01-01')
                   end as SRVC_BGNNG_DT
-                , case
-                    when 'SRVC_ENDG_DT' IS NULL then to_date('1960-01-01')
-                    else SRVC_ENDG_DT
-                  end as SRVC_ENDG_DT
+                , nullif(SRVC_ENDG_DT, '1960-01-01') as SRVC_ENDG_DT
                 , { TAF_Closure.fix_old_dates('ADMSN_DT') }
                 , { TAF_Closure.var_set_type5(var='ADMSN_HR_NUM', lpad=2, lowerbound=0, upperbound=23) }
                 , { TAF_Closure.fix_old_dates('DSCHRG_DT') }
                 , { TAF_Closure.var_set_type5(var='DSCHRG_HR_NUM', lpad=2, lowerbound=0, upperbound=23) }
                 , case
                     when ADJDCTN_DT < '1600-01-01' then '1599-12-31'
-                    when 'ADJDCTN_DT' IS NULL then to_date('1960-01-01')
-                    else ADJDCTN_DT
+                    else nullif(ADJDCTN_DT, '1960-01-01')
                   end as ADJDCTN_DT
                 , { TAF_Closure.fix_old_dates('MDCD_PD_DT') }
                 , { TAF_Closure.var_set_type2(var='SECT_1115A_DEMO_IND', lpad=0, cond1='0', cond2='1') }


### PR DESCRIPTION
## What is this?
This is a fix to handle how default SAS dates (January 1, 1960) are handled in the Long-Term Care claims header file type.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I ran the Long-Term Care Databricks job for a given state (California) where we knew this issue existed.
https://databricks-val-data.macbisdw.cmscloud.local/#job/200471/run/12054141

When the job completed, I reviewed the outputted data using this Notebook (and confirmed no more default SAS dates in output):
https://databricks-val-data.macbisdw.cmscloud.local/#notebook/3692682

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5859

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_