### PR TITLE
MACDC-5725 ancient dates - Update BSF_Metadata.py

### DIFF
--- a/taf/BSF/BSF_Metadata.py
+++ b/taf/BSF/BSF_Metadata.py
@@ -910,9 +910,9 @@ class BSF_Metadata:
         Function that takes any date earlier than 1600-01-01 and defaults it to 1599-12-31.
         """
         return f"""case
-            when {column} < '1600-01-01' then '1599-12-31'
-            else {column} end as {column}
-        """
+              when {column} < '1600-01-01' then CAST('1599-12-31' AS DATE)
+              else CAST({column} AS DATE) 
+              end as {column}"""
 
     cleanser = {
         'SSN_NUM': cleanSSN,
@@ -941,6 +941,7 @@ class BSF_Metadata:
 
     epochal = [
         'BIRTH_DT',
+        'DEATH_DT',
         'IMGRTN_STUS_5_YR_BAR_END_DT'
     ]
 
@@ -1780,7 +1781,7 @@ class BSF_Metadata:
         'ELGBL_1ST_NAME',
         'ELGBL_LAST_NAME',
         'ELGBL_MDL_INITL_NAME',
-        'cast(BIRTH_DT as date) as BIRTH_DT',
+        'BIRTH_DT',
         'DEATH_DT',
         'cast(AGE_NUM as integer) as AGE_NUM',
         'AGE_GRP_FLAG',
@@ -1793,7 +1794,7 @@ class BSF_Metadata:
         'CTZNSHP_VRFCTN_IND',
         'IMGRTN_STUS_CD',
         'IMGRTN_VRFCTN_IND',
-        'cast(IMGRTN_STUS_5_YR_BAR_END_DT as DATE) as IMGRTN_STUS_5_YR_BAR_END_DT',
+        'IMGRTN_STUS_5_YR_BAR_END_DT',
         'OTHR_LANG_HOME_CD',
         'PRMRY_LANG_FLAG',
         'ENGLSH_PRFCNCY_CD as PRMRY_LANG_ENGLSH_PRFCNCY_CD',


### PR DESCRIPTION
related issue: [MACDC-5725](https://cms-dataconnect.atlassian.net/jira/software/c/projects/MACDC/issues/MACDC-5725)

## What is this?
fix to properly reset dates older than 1/1/1600 to 12/31/1599 for all date columns identified in the BSF Technical Specification (3 total).

## How would you classify this change (feature, bug, maintenance, etc.)?
bug fix

## How did I test this (if code change)?
reviewed SQL logic in databricks notebook, did _not_ run a full BSF build

## Is there accompanying documentation for this change?
requirements can be found in the BSF Technical Specification

## Issues Encountered
NOTE: the BSF_Metadata attribute `output_columns` contains CAST expressions which may prevent conditional searching by column name alone

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x ] Is the issue number and a short description in the subject line?
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_

[MACDC-5725]: https://cms-dataconnect.atlassian.net/browse/MACDC-5725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ