### PR TITLE
MACDC-5743 Add upper flag to correct tooth number

### DIFF
--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -70,7 +70,7 @@ class OTL:
                 , { TAF_Closure.var_set_prtype('SRVCNG_PRVDR_TYPE_CD') }
                 , { TAF_Closure.var_set_spclty('SRVCNG_PRVDR_SPCLTY_CD') }
                 , { TAF_Closure.var_set_type4('TOOTH_DSGNTN_SYS_CD', 'YES', cond1='JO', cond2='JP') }
-                , { TAF_Closure.var_set_type1('TOOTH_NUM') }
+                , { TAF_Closure.var_set_type1('TOOTH_NUM', upper=True) }
                 , case when lpad(TOOTH_ORAL_CVTY_AREA_DSGNTD_CD, 2, '0') in ('20', '30', '40') then lpad(TOOTH_ORAL_CVTY_AREA_DSGNTD_CD, 2, '0')
                     else { TAF_Closure.var_set_type5('TOOTH_ORAL_CVTY_AREA_DSGNTD_CD', lpad=2, lowerbound=0, upperbound=10, multiple_condition='YES') }
                 , { TAF_Closure.var_set_type4('TOOTH_SRFC_CD', 'YES', cond1='B', cond2='D', cond3='F', cond4='I', cond5='L', cond6='M', cond7='O') }


### PR DESCRIPTION
## What is this?
This corrects a issue with the character casing of tooth number values from T-MSIS. In TAF, they should all be stored as upper case values, which can be accomplished by passing the upper flag to the `var_set_type1` definition

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
A wheel was built and copied to DBFS, then installed as a Notebook-scoped library [here](https://databricks-val-data.macbisdw.cmscloud.local/#notebook/3694950/command/3695417)

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5743

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_