### PR TITLE
MACDC-5510 Changed save mode to avoid conflicts

### DIFF
--- a/taf/TAF_Runner.py
+++ b/taf/TAF_Runner.py
@@ -751,7 +751,7 @@ class TAF_Runner():
                                 StructField("CCS_Label", StringType(), True)])
         ccs_table: DataFrame = spark.createDataFrame(data=ccs_rows, schema=df_schema)
         ccs_table.write.partitionBy("CCS_Label").format("delta").\
-            saveAsTable(name=f"{self.DA_SCHEMA}.ccs_sp_mapping", mode="overwrite")
+            saveAsTable(name=f"{self.DA_SCHEMA}.ccs_sp_mapping", mode="ignore")
 
         self.logger.info('Creating SSN Indicator View...')
 


### PR DESCRIPTION
## What is this?
During the monthly TAF run, we encountered conflicts with the claim runner jobs trying to write the CCS services and procedures data for each run. This data is static and does not change frequently (typically annually). Based on this, the save mode has been updated to `ignore` which is similar to a `CREATE TABLE IF NOT EXISTS` in SQL.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I tested this code by completing the monthly run with concurrent claim file types (IP, LT, the OT).

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5510

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_