### PR TITLE
MACDC-5133 Truncate DRG relative weights

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -192,7 +192,7 @@ class IPH:
                 , { TAF_Closure.var_set_type6('MDCD_DSH_PD_AMT', cond1='888888888.88') }
                 , { TAF_Closure.var_set_type6('DRG_OUTLIER_AMT', cond1='888888888.88') }
 
-                , drg_rltv_wt_num
+                , floor(drg_rltv_wt_num * 10000) / 10000 AS drg_rltv_wt_num
 
                 , { TAF_Closure.var_set_type6('MDCR_PD_AMT', cond1='888888888.88', cond2='8888888.88', cond3='88888888888.00', cond4='88888888888.88', cond5='99999999999.00', cond6='9999999999.99') }
                 , { TAF_Closure.var_set_type6('TOT_MDCR_DDCTBL_AMT', cond1='888888888.88', cond2='99999', cond3='88888888888.00') }


### PR DESCRIPTION
## What is this?
In order to match production TAF data, we need to truncate DRG relative weights that have more than four decimal digits. In Databricks, type coercion rounds up which changes some relative weight values. 

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
A wheel was built with this commit included as part of May 2023's run. After that, the full file comparison yielded no differences in `TAF_COMPARE.__COMPARE_IPH`. Results were published to Confluence [here](https://cms-dataconnect.atlassian.net/wiki/spaces/TDRI/pages/25189842947/TAF+User+Acceptance+Testing).

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5133

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_