### PR TITLE
MACDC-5638 Remove circular reference to current DE

### DIFF
--- a/taf/DE/DE_Runner.py
+++ b/taf/DE/DE_Runner.py
@@ -104,7 +104,6 @@ class DE_Runner(TAF_Runner):
             for pyear in self.PYEARS:
                 self.max_run_id(file="DE", inyear=pyear)
 
-        self.max_run_id(file="DE", inyear=self.YEAR)
         self.max_run_id(file="BSF", inyear=self.YEAR)
         self.max_run_id(file="IP", inyear=self.YEAR)
         self.max_run_id(file="LT", inyear=self.YEAR)


### PR DESCRIPTION
## What is this?
When input data to the Annual Demographics and Eligibility process was reviewed, we noticed that the current year's Annual Demographics and Eligibility data was included as part of the process to identify maximum run ID values. This is not consistent with the current production process.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I visually compared the production SAS code to confirm generated SQL for each file type's maximum run IDs was consistent.

<details><summary>SQL Generated from production SAS code</summary>
```     %max_run_id(file=BSF, tbl=taf_mon_bsf);

	 %max_run_id(file=IP)
	 %max_run_id(file=LT)
	 %max_run_id(file=OT)
	 %max_run_id(file=RX)

	 %macro priorids;

		 %if &pyears. ne  %then %do;
		    
			%do p=1 %to %sysfunc(countw(&pyears.));
		 		%let pyear=%scan(&pyears.,&p.);

		 		%max_run_id(file=DE, tbl=taf_ann_de_base, inyear=&pyear.)

			%end;

		 %end;

	   %mend priorids;
	   %priorids;
</details>

<details><summary>SQL Generated from TAF library</summary>

-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_DE_2022_nat AS

            SELECT DE_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS DE_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "DE"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2022"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY DE_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_DE_2022_ss AS

            SELECT DE_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS DE_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "DE"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2022"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY DE_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_DE_2022 AS

            SELECT DISTINCT DE_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.DE_fil_dt, b.DE_fil_dt) AS DE_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_DE_2022_nat a
                FULL JOIN max_run_id_DE_2022_ss b ON a.DE_fil_dt = b.DE_fil_dt

                UNION ALL

                SELECT DE_fil_dt
                    ,da_run_id
                FROM max_run_id_DE_2022_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_DE_2022 AS

            SELECT
        
                 substring(a.DE_fil_dt, 1, 4) AS DE_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_DE_2022 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.DE_fil_dt
                ,b.submtg_state_cd
        ;
-- preplan

            INSERT INTO taf_python_v4.TAF_ANN_INP_SRC
            SELECT
                 13292140 AS ANN_DA_RUN_ID
                ,'ade' as ann_fil_type
                ,SUBMTG_STATE_CD
                ,lower('DE') as src_fil_type
                ,DE_FIL_DT as src_fil_dt
                ,DA_RUN_ID AS SRC_DA_RUN_ID
                ,fil_cret_dt as src_fil_creat_dt
            FROM max_run_id_DE_2022
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_DE_2021_nat AS

            SELECT DE_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS DE_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "DE"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2021"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY DE_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_DE_2021_ss AS

            SELECT DE_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS DE_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "DE"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2021"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY DE_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_DE_2021 AS

            SELECT DISTINCT DE_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.DE_fil_dt, b.DE_fil_dt) AS DE_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_DE_2021_nat a
                FULL JOIN max_run_id_DE_2021_ss b ON a.DE_fil_dt = b.DE_fil_dt

                UNION ALL

                SELECT DE_fil_dt
                    ,da_run_id
                FROM max_run_id_DE_2021_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_DE_2021 AS

            SELECT
        
                 substring(a.DE_fil_dt, 1, 4) AS DE_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_DE_2021 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.DE_fil_dt
                ,b.submtg_state_cd
        ;
-- preplan

            INSERT INTO taf_python_v4.TAF_ANN_INP_SRC
            SELECT
                 13292140 AS ANN_DA_RUN_ID
                ,'ade' as ann_fil_type
                ,SUBMTG_STATE_CD
                ,lower('DE') as src_fil_type
                ,DE_FIL_DT as src_fil_dt
                ,DA_RUN_ID AS SRC_DA_RUN_ID
                ,fil_cret_dt as src_fil_creat_dt
            FROM max_run_id_DE_2021
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_BSF_2023_nat AS

            SELECT BSF_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS BSF_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "BSF"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY BSF_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_BSF_2023_ss AS

            SELECT BSF_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS BSF_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "BSF"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY BSF_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_BSF_2023 AS

            SELECT DISTINCT BSF_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.BSF_fil_dt, b.BSF_fil_dt) AS BSF_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_BSF_2023_nat a
                FULL JOIN max_run_id_BSF_2023_ss b ON a.BSF_fil_dt = b.BSF_fil_dt

                UNION ALL

                SELECT BSF_fil_dt
                    ,da_run_id
                FROM max_run_id_BSF_2023_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_BSF_2023 AS

            SELECT
        
                a.BSF_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_BSF_2023 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.BSF_fil_dt
                ,b.submtg_state_cd
        ;
-- preplan

            INSERT INTO taf_python_v4.TAF_ANN_INP_SRC
            SELECT
                 13292140 AS ANN_DA_RUN_ID
                ,'ade' as ann_fil_type
                ,SUBMTG_STATE_CD
                ,lower('BSF') as src_fil_type
                ,BSF_FIL_DT as src_fil_dt
                ,DA_RUN_ID AS SRC_DA_RUN_ID
                ,fil_cret_dt as src_fil_creat_dt
            FROM max_run_id_BSF_2023
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_IP_2023_nat AS

            SELECT IP_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS IP_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "IP"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY IP_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_IP_2023_ss AS

            SELECT IP_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS IP_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "IP"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY IP_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_IP_2023 AS

            SELECT DISTINCT IP_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.IP_fil_dt, b.IP_fil_dt) AS IP_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_IP_2023_nat a
                FULL JOIN max_run_id_IP_2023_ss b ON a.IP_fil_dt = b.IP_fil_dt

                UNION ALL

                SELECT IP_fil_dt
                    ,da_run_id
                FROM max_run_id_IP_2023_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_IP_2023 AS

            SELECT
        
                a.IP_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_IP_2023 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.IP_fil_dt
                ,b.submtg_state_cd
        ;
-- preplan

            INSERT INTO taf_python_v4.TAF_ANN_INP_SRC
            SELECT
                 13292140 AS ANN_DA_RUN_ID
                ,'ade' as ann_fil_type
                ,SUBMTG_STATE_CD
                ,lower('IP') as src_fil_type
                ,IP_FIL_DT as src_fil_dt
                ,DA_RUN_ID AS SRC_DA_RUN_ID
                ,fil_cret_dt as src_fil_creat_dt
            FROM max_run_id_IP_2023
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_LT_2023_nat AS

            SELECT LT_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS LT_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "LT"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY LT_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_LT_2023_ss AS

            SELECT LT_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS LT_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "LT"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY LT_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_LT_2023 AS

            SELECT DISTINCT LT_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.LT_fil_dt, b.LT_fil_dt) AS LT_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_LT_2023_nat a
                FULL JOIN max_run_id_LT_2023_ss b ON a.LT_fil_dt = b.LT_fil_dt

                UNION ALL

                SELECT LT_fil_dt
                    ,da_run_id
                FROM max_run_id_LT_2023_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_LT_2023 AS

            SELECT
        
                a.LT_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_LT_2023 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.LT_fil_dt
                ,b.submtg_state_cd
        ;
-- preplan

            INSERT INTO taf_python_v4.TAF_ANN_INP_SRC
            SELECT
                 13292140 AS ANN_DA_RUN_ID
                ,'ade' as ann_fil_type
                ,SUBMTG_STATE_CD
                ,lower('LT') as src_fil_type
                ,LT_FIL_DT as src_fil_dt
                ,DA_RUN_ID AS SRC_DA_RUN_ID
                ,fil_cret_dt as src_fil_creat_dt
            FROM max_run_id_LT_2023
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_OT_2023_nat AS

            SELECT OT_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS OT_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "OT"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY OT_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_OT_2023_ss AS

            SELECT OT_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS OT_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "OT"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY OT_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_OT_2023 AS

            SELECT DISTINCT OT_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.OT_fil_dt, b.OT_fil_dt) AS OT_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_OT_2023_nat a
                FULL JOIN max_run_id_OT_2023_ss b ON a.OT_fil_dt = b.OT_fil_dt

                UNION ALL

                SELECT OT_fil_dt
                    ,da_run_id
                FROM max_run_id_OT_2023_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_OT_2023 AS

            SELECT
        
                a.OT_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_OT_2023 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.OT_fil_dt
                ,b.submtg_state_cd
        ;
-- preplan

            INSERT INTO taf_python_v4.TAF_ANN_INP_SRC
            SELECT
                 13292140 AS ANN_DA_RUN_ID
                ,'ade' as ann_fil_type
                ,SUBMTG_STATE_CD
                ,lower('OT') as src_fil_type
                ,OT_FIL_DT as src_fil_dt
                ,DA_RUN_ID AS SRC_DA_RUN_ID
                ,fil_cret_dt as src_fil_creat_dt
            FROM max_run_id_OT_2023
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_RX_2023_nat AS

            SELECT RX_fil_dt
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS RX_fil_dt
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "RX"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) = 0
                )

            GROUP BY RX_fil_dt
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_RX_2023_ss AS

            SELECT RX_fil_dt
                ,submtg_state_cd
                ,max(da_run_id) AS da_run_id
            FROM (
                SELECT substring(job_parms_txt, 1, 4) || substring(job_parms_txt, 6, 2) AS RX_fil_dt
                    ,regexp_extract(substring(job_parms_txt, 10), '([0-9]{2})') AS submtg_state_cd
                    ,da_run_id
                FROM taf_python_v4.job_cntl_parms
                WHERE upper(substring(fil_type, 2)) = "RX"
                    AND sucsfl_ind = 1
                    AND substring(job_parms_txt, 1, 4) = "2023"
        
                    AND charindex('submtg_state_cd in', regexp_replace(job_parms_txt, '\\s+', ' ')) > 0
                )

            GROUP BY RX_fil_dt
                ,submtg_state_cd
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW job_cntl_parms_both_RX_2023 AS

            SELECT DISTINCT RX_fil_dt
                ,da_run_id
            FROM (
                SELECT coalesce(a.RX_fil_dt, b.RX_fil_dt) AS RX_fil_dt
                    ,CASE
                        WHEN a.da_run_id > b.da_run_id
                            OR b.da_run_id IS NULL
                            THEN a.da_run_id
                        ELSE b.da_run_id
                        END AS da_run_id
                FROM max_run_id_RX_2023_nat a
                FULL JOIN max_run_id_RX_2023_ss b ON a.RX_fil_dt = b.RX_fil_dt

                UNION ALL

                SELECT RX_fil_dt
                    ,da_run_id
                FROM max_run_id_RX_2023_nat
                ) c
        ;
-- preplan

            CREATE OR REPLACE TEMPORARY VIEW max_run_id_RX_2023 AS

            SELECT
        
                a.RX_fil_dt
            
                ,b.submtg_state_cd
                ,max(b.da_run_id) AS da_run_id
                ,max(b.fil_cret_dt) AS fil_cret_dt
            FROM job_cntl_parms_both_RX_2023 a
            INNER JOIN (
                SELECT da_run_id
                    ,incldd_state_cd AS submtg_state_cd
                    ,fil_cret_dt
                FROM taf_python_v4.efts_fil_meta
                WHERE incldd_state_cd != 'Missing'
                ) b ON a.da_run_id = b.da_run_id
        
            GROUP BY a.RX_fil_dt
                ,b.submtg_state_cd
        ;

</details>

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-5638

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_