### PR TITLE
MACDC-6287 AUP Inconsistencies IP Stays and Days

### DIFF
--- a/taf/UP/BASE_IP.py
+++ b/taf/UP/BASE_IP.py
@@ -345,6 +345,7 @@ class BASE_IP(UP):
                         -- Determine when to create a second stay - if the difference between current admission date and prior
                         --          discharge date is more than 1 day, OR the difference is 0 or 1 day (either same or contiguous days)
                         --          AND the prior patient status code indicates discharge, then create a second stay
+                        -- Note that parameters for datediff in Spark are opposite Redshift
 
                         ,CASE
                             WHEN datediff(claim_admsn_dt, coalesce(claim_dschrg_dt_lag, claim_admsn_dt)) > 1

--- a/taf/UP/BASE_IP.py
+++ b/taf/UP/BASE_IP.py
@@ -347,9 +347,9 @@ class BASE_IP(UP):
                         --          AND the prior patient status code indicates discharge, then create a second stay
 
                         ,CASE
-                            WHEN datediff(coalesce(claim_dschrg_dt_lag, claim_admsn_dt), claim_admsn_dt) > 1
+                            WHEN datediff(claim_admsn_dt, coalesce(claim_dschrg_dt_lag, claim_admsn_dt)) > 1
                                 OR (
-                                    datediff(coalesce(claim_dschrg_dt_lag, claim_admsn_dt), claim_admsn_dt) IN (
+                                    datediff(claim_admsn_dt, coalesce(claim_dschrg_dt_lag, claim_admsn_dt)) IN (
                                         0
                                         ,1
                                         )

--- a/taf/__init__.py
+++ b/taf/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "PI02.03"
+__version__ = "PI02.04"


### PR DESCRIPTION
## What is this?
This is a fix to date arithmetic used to trigger the creation of a second Inpatient stay based on admission and discharge dates.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
I made the change locally and compared generated SQL for the corresponding CASE statement to confirm the correct positions for `CLAIM_ADMSN_DT` and `CLAIM_DSCHRG_DT_LAG`. After re-running the annual use and payment file type, I reviewed the [full file comparison data](https://cms-dataconnect.atlassian.net/wiki/spaces/TDRI/pages/25189842947/TAF+User+Acceptance+Testing) and confirmed `IP Stays` and `IP Days` were calculated consistently with production data.

## Is there accompanying documentation for this change?
https://cms-dataconnect.atlassian.net/browse/MACDC-6287

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_