### PR TITLE
MACDC-6394 Update TAF deploy slack alert

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -83,10 +83,8 @@ jobs:
       uses: slackapi/slack-github-action@v1.23.0
       with:
         channel-id: 'dc-deploy'
-        slack-message: "${{ steps.set-emoji.outputs.emoji }} ${{ github.workflow }} #${{ github.run_number }}: ${{ job.status }}\n
-          Version: ${{ steps.version.outputs.version }}\n
-          Triggered by: ${{ github.event_name }}\n
-          ${{ env.BUILD_URL }}"
+        slack-message: "${{ steps.set-emoji.outputs.emoji }} <${{ env.BUILD_URL }}| ${{ github.repository }} ${{ github.workflow }} #${{ github.run_number }}>: ${{ job.status }}\n
+          Version: ${{ steps.version.outputs.version }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.DATACONNECT_SLACK_BOT_TOKEN }}
         BUILD_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION

## What is this?
This tweaks the slack message that goes to the [#dc-deploy channel in the DataConnect slack](https://dataconnect-workspace.slack.com/archives/C02QE4R4BPE) when the [TAF Build and Deploy job](https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/actions/workflows/build-and-deploy.yml) runs.

It takes out the triggered by event line and makes the first line the link to the job.

## How would you classify this change (feature, bug, maintenance, etc.)?
Minor improvements

## How did I test this (if code change)?
Well, I didn't because I don't want to trigger the deploy job, but the link is something we already do elsewhere, like with the secrets scan alerts.
<img width="485" alt="Screenshot 2023-06-15 at 2 34 30 PM" src="https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/assets/92479333/241e9c2a-ec56-4102-b01c-f0f3a91851e1">

## Is there accompanying documentation for this change?
Nope

## Issues Encountered

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_