### PR TITLE
DBDAART-2412 Set all timestamp updates to use EST

### DIFF
--- a/taf/DE/DE.py
+++ b/taf/DE/DE.py
@@ -338,7 +338,7 @@ class DE(TAF):
         z = ""
         if as_select is False:
             z += f"""
-                ,current_timestamp() as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,cast(NULL as timestamp) as REC_UPDT_TS
                 ,{self.de.DA_RUN_ID} as DA_RUN_ID
                 ,SUBMTG_STATE_CD

--- a/taf/DE/DE0001BASE.py
+++ b/taf/DE/DE0001BASE.py
@@ -793,7 +793,7 @@ class DE0001BASE(DE):
                 ,'{self.de.VERSION}' as ANN_DE_VRSN
                 ,MSIS_IDENT_NUM_comb
                 {self.basecols()}
-                ,current_timestamp() as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,cast(NULL as timestamp) as REC_UPDT_TS
                 ,{self.de.DA_RUN_ID} as DA_RUN_ID
                 ,SUBMTG_STATE_CD_comb

--- a/taf/UP/BASE_FNL.py
+++ b/taf/UP/BASE_FNL.py
@@ -155,7 +155,7 @@ class BASE_FNL(UP):
             SELECT 
                      { self.table_id_cols() }
                     ,{",".join(self.basecols)}
-                    ,current_timestamp() as REC_ADD_TS
+                    ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                     ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM base_fnl_{self.year}
         """

--- a/taf/UP/TOP.py
+++ b/taf/UP/TOP.py
@@ -85,7 +85,7 @@ class TOP(UP):
                 ,CLM_TYPE_CD
                 ,CLM_TOT
                 ,SUM_TOT_MDCD_PD
-                ,current_timestamp() as REC_ADD_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,cast(NULL as timestamp) as REC_UPDT_TS
             FROM top_fnl_{self.year}
         """


### PR DESCRIPTION
## What is this?

https://jiraent.cms.gov/browse/DBDAART-2412

This is a bug fix for setting all timestamps to use EST. This will make timestamps consistent throughout the project. The old TAF system uses EDT which has a potential downside of having an ambiguous time during the fall time switch between 1 and 2 AM. EST does not follow daylight savings time and does not have this issue.

## How would you classify this change (feature, bug, maintenance, etc.)?

bug

## How did I test this (if code change)?

## Is there accompanying documentation for this change?

## Issues Encountered

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [ ] Is the issue number and a short description in the subject line?
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_