### PR TITLE
Misplaced comma

### DIFF
--- a/taf/BSF/BSF_Metadata.py
+++ b/taf/BSF/BSF_Metadata.py
@@ -1925,7 +1925,7 @@ class BSF_Metadata:
         '_1932A_SPO_FLAG',
         '_1915A_SPO_FLAG',
         '_1937_ABP_SPO_FLAG',
-        'cast(_1115A_PRTCPNT_FLAG as integer) as _1115A_PRTCPNT_FLAG,'
+        'cast(_1115A_PRTCPNT_FLAG as integer) as _1115A_PRTCPNT_FLAG',
         'WVR_ID1',
         'WVR_TYPE_CD1',
         'WVR_ID2',


### PR DESCRIPTION
Misplaced comma prevented 'WVR_ID1' from being identified as a separate column that needs to be uppercased.

Originally the ticket has 88 columns with potential missing casing. All of these columns (except WVR_ID1) are in fact being cast as upper case in the FinalFormatter function in BSF_Metadata.py. There was an issue with WVR_ID1 because there was a misplaced comma in the output_columns list which prevented it from being identified and therefore uppercased.

## What is this?
Fix for DBDAART-2106
https://jiraent.cms.gov/browse/DBDAART-2106

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug

## How did I test this (if code change)?
Print out sql code (did not do a full run and write to data tables)

## Is there accompanying documentation for this change?
No

## Issues Encountered
None

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [ x] Is the issue number and a short description in the subject line?
- [ ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_