### PR TITLE
DBDAART_2111 Casing corrections for ADJSTMT and LINE_ADJSTMT using upper()

### DIFF
--- a/taf/LT/LT.py
+++ b/taf/LT/LT.py
@@ -47,6 +47,7 @@ class LT(TAF):
         self.runner.append(self.st_fil_type, z)
 
         z = f"""
+            --- will this fail?
             create or replace temporary view {fl2}_LINE_PRE_NPPES as
             select
                 a.*,
@@ -79,7 +80,7 @@ class LT(TAF):
                 H.ORGNL_CLM_NUM = a.ORGNL_CLM_NUM_LINE and
                 H.ADJSTMT_CLM_NUM = a.ADJSTMT_CLM_NUM_LINE and
                 H.ADJDCTN_DT = a.ADJDCTN_DT_LINE and
-                H.ADJSTMT_IND = a.LINE_ADJSTMT_IND
+                upper(H.ADJSTMT_IND) = upper(a.LINE_ADJSTMT_IND)
         """
         self.runner.append(self.st_fil_type, z)
 
@@ -107,7 +108,7 @@ class LT(TAF):
                 , ORGNL_CLM_NUM_LINE
                 , ADJSTMT_CLM_NUM_LINE
                 , ADJDCTN_DT_LINE
-                , LINE_ADJSTMT_IND
+                , upper(LINE_ADJSTMT_IND) as LINE_ADJSTMT_IND
                 , max(RN) as NUM_CLL
                 , sum (case when substring(lpad(REV_CD,4,'0'),1,2)='01' or substring(lpad(REV_CD,4,'0'),1,3) in ('020', '021')
                         then MDCD_PD_AMT
@@ -168,7 +169,7 @@ class LT(TAF):
                 HEADER.ORGNL_CLM_NUM = CONSTR.ORGNL_CLM_NUM_LINE and
                 HEADER.ADJSTMT_CLM_NUM = CONSTR.ADJSTMT_CLM_NUM_LINE and
                 HEADER.ADJDCTN_DT = CONSTR.ADJDCTN_DT_LINE and
-                HEADER.ADJSTMT_IND = CONSTR.LINE_ADJSTMT_IND
+                upper(HEADER.ADJSTMT_IND) = upper(CONSTR.LINE_ADJSTMT_IND)
         """
         self.runner.append(self.st_fil_type, z)
 

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -191,8 +191,8 @@ class LTH:
                 select
                     *,
                     case when ADJSTMT_IND is NOT NULL and
-                    trim(ADJSTMT_IND) in ('0', '1', '2', '3', '4', '5', '6')
-                    then trim(ADJSTMT_IND) else NULL end as ADJSTMT_IND_CLEAN
+                    trim(upper(ADJSTMT_IND)) in ('0', '1', '2', '3', '4', '5', '6')
+                    then trim(upper(ADJSTMT_IND)) else NULL end as ADJSTMT_IND_CLEAN
                 from
                     LT_HEADER_GROUPER
                 ) H

--- a/taf/LT/LTL.py
+++ b/taf/LT/LTL.py
@@ -39,7 +39,7 @@ class LTL:
                 , { TAF_Closure.var_set_type1('ORGNL_LINE_NUM') }
 
                 , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE, to_date('1960-01-01')) end as ADJDCTN_DT
-                ,LINE_ADJSTMT_IND_CLEAN as LINE_ADJSTMT_IND
+                ,upper(LINE_ADJSTMT_IND_CLEAN) as LINE_ADJSTMT_IND
 
                 , { TAF_Closure.var_set_tos('TOS_CD') }
 
@@ -90,8 +90,8 @@ class LTL:
                 select
                     *,
                     case when LINE_ADJSTMT_IND is NOT NULL and
-                    trim(LINE_ADJSTMT_IND) in ('0', '1', '2', '3', '4', '5', '6')
-                    then trim(LINE_ADJSTMT_IND) else NULL end as LINE_ADJSTMT_IND_CLEAN
+                    trim(upper(LINE_ADJSTMT_IND)) in ('0', '1', '2', '3', '4', '5', '6')
+                    then trim(upper(LINE_ADJSTMT_IND)) else NULL end as LINE_ADJSTMT_IND_CLEAN
                 from
                     LT_LINE
                 ) H

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -3,9 +3,9 @@ from taf.TAF_Closure import TAF_Closure
 
 class LT_Metadata:
     """
-    Create LT metadata.  
+    Create LT metadata.
     """
-    
+
     def selectDataElements(segment_id: str, alias: str):
         """
         Function to select data elements.  Selected data elements will be cleansed, checked against a validator,
@@ -19,7 +19,7 @@ class LT_Metadata:
         for i, item in enumerate(columns):
             if item in LT_Metadata.cleanser.keys():
                 columns[i] = LT_Metadata.cleanser.copy().get(item)(item, alias)
-            elif item in LT_Metadata.validator.keys():
+            elif item in LT_Metadata.validator.keys():  # this is a placeholder. It's not currently implemented
                 columns[i] = LT_Metadata.maskInvalidValues(item, alias)
             elif item in LT_Metadata.upper:
                 columns[i] = f"upper({alias}.{item}) as {str(item).lower()}"
@@ -29,18 +29,30 @@ class LT_Metadata:
             # qualify header columns
             if segment_id.casefold() == "clt00002":
                 if item in LT_Metadata.header_renames.keys():
-                    columns[i] = (
-                        columns[i].lower().split(" as ")[0]
-                        + f" as {LT_Metadata.header_renames.get(item).lower()}"
-                    )
+                    if item in LT_Metadata.upper:
+                        columns[i] = (
+                            "upper(" + columns[i].lower().split(" as ")[0]
+                            + f") as {LT_Metadata.header_renames.get(item).lower()}"
+                        )
+                    else:
+                        columns[i] = (
+                            columns[i].lower().split(" as ")[0]
+                            + f" as {LT_Metadata.header_renames.get(item).lower()}"
+                        )
 
             # qualify line columns
             if segment_id.casefold() == "clt00003":
                 if item in LT_Metadata.line_renames.keys():
-                    columns[i] = (
-                        columns[i].lower().split(" as ")[0]
-                        + f" as {LT_Metadata.line_renames.get(item).lower()}"
-                    )
+                    if item in LT_Metadata.upper:
+                        columns[i] = (
+                            "upper(" + columns[i].lower().split(" as ")[0]
+                            + f") as {LT_Metadata.line_renames.get(item).lower()}"
+                        )
+                    else:
+                        columns[i] = (
+                            columns[i].lower().split(" as ")[0]
+                            + f" as {LT_Metadata.line_renames.get(item).lower()}"
+                        )
 
         return new_line_comma.join(columns)
 
@@ -359,12 +371,14 @@ class LT_Metadata:
     upper = [
         "ADJSTMT_LINE_NUM",
         "ADJSTMT_LINE_RSN_CD",
+        "ADJSTMT_IND",
         "BLG_UNIT_CD",
         "BNFT_TYPE_CD",
         "CLL_STUS_CD",
         "CMS_64_FED_REIMBRSMT_CTGRY_CD",
         "HCPCS_RATE",
         "IMNZTN_TYPE_CD",
+        "LINE_ADJSTMT_IND",
         "MSIS_IDENT_NUM",
         "NDC_CD",
         "NDC_UOM_CD",

--- a/taf/TAF_Claims.py
+++ b/taf/TAF_Claims.py
@@ -211,7 +211,7 @@ class TAF_Claims():
                 ,A.ADJSTMT_CLM_NUM
                 ,A.SUBMTG_STATE_CD
                 ,coalesce(A.ADJDCTN_DT, to_date('1960-01-01')) as ADJDCTN_DT
-                ,A.ADJSTMT_IND
+                ,upper(A.ADJSTMT_IND) as ADJSTMT_IND
                 {self.select_date(fl)}
 
             from
@@ -258,7 +258,7 @@ class TAF_Claims():
                         ,H.ADJSTMT_CLM_NUM
                         ,H.SUBMTG_STATE_CD
                         ,H.ADJDCTN_DT
-                        ,H.ADJSTMT_IND
+                        ,UPPER(H.ADJSTMT_IND) as ADJSTMT_IND
                         ,MAX(L.SRVC_ENDG_DT) as SRVC_ENDG_DT
                         ,MAX(L.SRVC_BGNNG_DT) as SRVC_BGNNG_DT
 
@@ -324,7 +324,7 @@ class TAF_Claims():
                    ,coalesce(upper(ADJSTMT_CLM_NUM), '~') as ADJSTMT_CLM_NUM
                    ,SUBMTG_STATE_CD
                    ,coalesce(ADJDCTN_DT, to_date('1960-01-01')) as ADJDCTN_DT
-                   ,COALESCE(ADJSTMT_IND,'X') as ADJSTMT_IND
+                   ,COALESCE(UPPER(ADJSTMT_IND),'X') as ADJSTMT_IND
 
                 --- {TMSIS_SCHEMA}.TMSIS_CLM_FMLY_{fl} F
                 --- subquery contains the claim family view definition
@@ -386,7 +386,7 @@ class TAF_Claims():
                         A.ADJSTMT_CLM_NUM,
                         A.SUBMTG_STATE_CD,
                         A.ADJDCTN_DT,
-                        A.ADJSTMT_IND,
+                        upper(A.ADJSTMT_IND) as ADJSTMT_IND,
 
                         null as SRVC_ENDG_DT_DRVD_L,
                         null as SRVC_ENDG_DT_CD_L
@@ -405,7 +405,7 @@ class TAF_Claims():
                         B.ADJSTMT_CLM_NUM,
                         B.SUBMTG_STATE_CD,
                         B.ADJDCTN_DT,
-                        B.ADJSTMT_IND,
+                        upper(B.ADJSTMT_IND) as ADJSTMT_IND,
                         case
                             when nullif(B.SRVC_ENDG_DT, '01JAN1960') is null
                             or SRVC_ENDG_DT is null then SRVC_BGNNG_DT

--- a/taf/TAF_Grouper.py
+++ b/taf/TAF_Grouper.py
@@ -558,7 +558,7 @@ class TAF_Grouper:
                 and l.ORGNL_CLM_NUM_LINE = a.ORGNL_CLM_NUM
                 and l.ADJSTMT_CLM_NUM_LINE = a.ADJSTMT_CLM_NUM
                 and l.ADJDCTN_DT_LINE = a.ADJDCTN_DT
-                and l.LINE_ADJSTMT_IND = a.ADJSTMT_IND"""
+                and upper(l.LINE_ADJSTMT_IND) = upper(a.ADJSTMT_IND)"""
             )
 
         return "\n".join(join)
@@ -653,7 +653,7 @@ class TAF_Grouper:
                     ORGNL_CLM_NUM_LINE,
                     ADJSTMT_CLM_NUM_LINE,
                     ADJDCTN_DT_LINE,
-                    LINE_ADJSTMT_IND
+                    UPPER(LINE_ADJSTMT_IND) as LINE_ADJSTMT_IND
 
                     ,max(case when TEMP_TAXONMY_LINE is null
             """


### PR DESCRIPTION
## What is this?
This is field casing corrections to be in line with the original SAS code. This set of changes is related to Long Term header and line tables in the new system. Specifically the fields of ADJSTMT_IND and LINE_ADJSTMT_IND. In various sections of the code we've wrapped the fields with UPPER() function to force upper casing.

## How would you classify this change (feature, bug, maintenance, etc.)?
Bug/Maintenance

## How did I test this (if code change)?
I've used the LT_Runner with a test case and reviewed the results of the SQL queries in the logs to show the fields.

## Is there accompanying documentation for this change?
No

## Issues Encountered
None on a successful run.

*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x] Is the issue number and a short description in the subject line?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_