### PR TITLE
DBDAART-1483  Added 101200000X to OTMTAX list

### DIFF
--- a/taf/TAF_Grouper.py
+++ b/taf/TAF_Grouper.py
@@ -217,6 +217,7 @@ class TAF_Grouper:
         "364SP0813X",
         "385HR2055X",
         "385HR2060X",
+        "101200000X"
         ]
 
     otstax = [


### PR DESCRIPTION
## What is this?

Missing Taxonomy code to OTMTAX list was causing fields in OT and AUP to not match SAS.   Change is to add 101200000X to OTMAX list.

## How would you classify this change (feature, bug, maintenance, etc.)?

BUG

## How did I test this (if code change)?

before and after sql attached to ticket. 

## Is there accompanying documentation for this change?

https://jiraent.cms.gov/browse/DBDAART-1483

## Issues Encountered

None 
*Optional section to include any challenges encountered, options considered, and the approach chosen.*

## PR Checklist
- [x ] Is the issue number and a short description in the subject line?
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

_Credit to TMSIS PR template and https://embeddedartistry.com/blog/2017/8/4/a-github-pull-request-template-for-your-projects_