### PR TITLE
[No Ticket] Fix TAF Long Description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,20 @@ from setuptools import find_packages, setup
 
 from taf import __version__
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
 setup(
     name="taf",
     python_requires=">=3.8",
     packages=find_packages(exclude=["tests", "tests.*"]),
     setup_requires=["wheel"],
-    long_description=long_description,
+    long_description=(
+        "This project aims to provide transparency to state "
+        "Medicaid agencies and other stakeholders who are interested in "
+        "the logic and processes that are used to create CMS’ interim "
+        "T-MSIS Analytic Files (TAF). These new TAF data sets exist "
+        "alongside T-MSIS and serve as an alternate data source tailored to "
+        "meet the broad research needs of the Medicaid and CHIP data user "
+        "community."
+    ),
     long_description_content_type="text/markdown",
     version=__version__,
     description="A package to generate T-MSIS analytic files using Databricks",


### PR DESCRIPTION
## What is this and why are we doing it?
While troubleshooting the wheel file creation process with a colleague, we noticed `setup.py` referenced the wrong location to populate the long description from `README.md`. Changing this to embed the description going forward.



## What are the security implications from this change?
None. This change should not introduce any additional security implications as it simply adds a textual description to the module used to build and distribute Python packages (not altering the pipeline in any meaningful way).

## How did I test this?
I ran `setup.py` locally and was able to successfully create a wheel file

## Should there be new or updated documentation for this change? (Be specific.)
No, the same process should be used to create a wheel file

## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
