### PR TITLE
DBDAART-3525 updated 01JAN1960 to 1960-01-01

### DIFF
--- a/taf/IP/IPL.py
+++ b/taf/IP/IPL.py
@@ -38,7 +38,7 @@ class IPL:
                 , { TAF_Closure.var_set_type1('ORGNL_LINE_NUM') }
                 , { TAF_Closure.var_set_type1('ADJSTMT_LINE_NUM') }
 
-                , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE,'01JAN1960') end as ADJDCTN_DT
+                , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE,'1960-01-01') end as ADJDCTN_DT
                 ,LINE_ADJSTMT_IND_CLEAN as LINE_ADJSTMT_IND
 
                 , { TAF_Closure.var_set_tos('TOS_CD') }


### PR DESCRIPTION
## What is this and why are we doing it?
Bug - Adjudication Date values of 1960-01-01 are to be recoded to NULL, and this recode was not working properly.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-3525

## What are the security implications from this change?
No

## How did I test this?
Before/After .sql attached to Jira ticket.   Created wheel with change, uploaded, and ran for month where the issue existed and verified that new python Adjudication date values matched SAS adjudication date values.  
Testing notebook here:   https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/4291831236183384/command/4291831236183836


## Should there be new or updated documentation for this change? (Be specific.)
No

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ N/A] I have commented my code, particularly in hard-to-understand areas
- [ N/A] I have made corresponding changes to the documentation
