### PR TITLE
Changed date format for recoding Adj date to null

### DIFF
--- a/taf/RX/RXL.py
+++ b/taf/RX/RXL.py
@@ -39,7 +39,7 @@ class RXL:
                 , { TAF_Closure.var_set_type1('ORGNL_LINE_NUM')  }
                 , { TAF_Closure.var_set_type1('ADJSTMT_LINE_NUM') }
 
-                ,case when ADJDCTN_DT_LINE < to_date('1600-01-01') then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE, to_date('01JAN1960')) end as ADJDCTN_DT
+                ,case when ADJDCTN_DT_LINE < to_date('1600-01-01') then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE, to_date('1960-01-01')) end as ADJDCTN_DT
                 ,LINE_ADJSTMT_IND_CLEAN as LINE_ADJSTMT_IND
 
                 , { TAF_Closure.var_set_tos('TOS_CD') }


### PR DESCRIPTION
## What is this and why are we doing it?
Potential bug, found it in IPL fixed it there, saw it in RXL as well.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-3601

## What are the security implications from this change?
No.


## How did I test this?
Before/After SQL attached to ticket.   Compared New RXL code to existing OTL/LTL code b/c they do the same thing.   Tested this change more extensively with a wheel file in IPL.


## Should there be new or updated documentation for this change? (Be specific.)
No

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ N/A] I have commented my code, particularly in hard-to-understand areas
- [ N/A] I have made corresponding changes to the documentation
