### PR TITLE
MACDC-3603 Fix several metadata issues

### DIFF
--- a/taf/APL/APL_Runner.py
+++ b/taf/APL/APL_Runner.py
@@ -191,7 +191,9 @@ class APL_Runner(TAF_Runner):
                 '{file.lower()}' as src_fil_type,
                 {file}_fil_dt as src_fil_dt,
                 da_run_id as src_da_run_id,
-                fil_cret_dt as src_fil_creat_dt
+                to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt,
+                from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
+                null as REC_UPDT_TS
 
             from max_run_id_{file}_{inyear}
         """

--- a/taf/APR/APR_Runner.py
+++ b/taf/APR/APR_Runner.py
@@ -201,7 +201,9 @@ class APR_Runner(TAF_Runner):
                 lower('{file}') as src_fil_type,
                 {file}_FIL_DT as src_fil_dt,
                 DA_RUN_ID as SRC_DA_RUN_ID,
-			    fil_cret_dt as src_fil_creat_dt
+                to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt,
+                from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
+                null as REC_UPDT_TS
 
             from max_run_id_{file}_{inyear}
         """

--- a/taf/DE/DE_Runner.py
+++ b/taf/DE/DE_Runner.py
@@ -286,7 +286,9 @@ class DE_Runner(TAF_Runner):
                 ,lower('{file}') as src_fil_type
                 ,{file}_FIL_DT as src_fil_dt
                 ,DA_RUN_ID AS SRC_DA_RUN_ID
-                ,fil_cret_dt as src_fil_creat_dt
+                ,to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
+                ,null as REC_UPDT_TS
             FROM max_run_id_{file}_{inyear}
         """
         self.prepend(z)

--- a/taf/TAF_Runner.py
+++ b/taf/TAF_Runner.py
@@ -320,7 +320,7 @@ class TAF_Runner():
         else:
             parms = f"{self.st_dt}" + ", " + "submtg_state_cd" + " " + "in" + " " + "(" + f"{self.state_code}" + ")"
 
-        print("DEBUG: " + f"""
+        insert_query = f"""
             INSERT INTO {self.DA_SCHEMA}.job_cntl_parms (
                 da_run_id
                ,fil_type
@@ -337,51 +337,23 @@ class TAF_Runner():
             )
             VALUES (
                 {self.DA_RUN_ID}
-               ,"{file_type}"
+               ,lower("{file_type}")
                ,1
                ,"{parms}"
-               ,concat("{self.VERSION}", ",", "7.1")
+               ,concat("{self.ITERATION}", ",", "7.1")
                ,NULL
                ,NULL
                ,False
                ,from_utc_timestamp(current_timestamp(), "EST")
                ,NULL
                ,False
-               ,concat("{self.VERSION}", ",", "7.1")
-            )
-        """)
-
-        spark.sql(
-            f"""
-            INSERT INTO {self.DA_SCHEMA}.job_cntl_parms (
-                da_run_id
-               ,fil_type
-               ,schld_ordr_num
-               ,job_parms_txt
-               ,cd_spec_vrsn_name
-               ,job_strt_ts
-               ,job_end_ts
-               ,sucsfl_ind
-               ,rec_add_ts
-               ,rec_updt_ts
-               ,rfrsh_vw_flag
-               ,taf_cd_spec_vrsn_name
-            )
-            VALUES (
-                {self.DA_RUN_ID}
-               ,"{file_type}"
-               ,1
-               ,"{parms}"
-               ,concat("{self.VERSION}", ",", "7.1")
-               ,NULL
-               ,NULL
-               ,False
-               ,from_utc_timestamp(current_timestamp(), "EST")
-               ,NULL
-               ,False
-               ,concat("{self.VERSION}", ",", "7.1")
+               ,concat("{self.ITERATION}", ",", "7.1")
             )
         """
+        print("DEBUG: " + insert_query)
+
+        spark.sql(
+            insert_query
         )
 
     def job_control_updt(self):

--- a/taf/UP/UP_Runner.py
+++ b/taf/UP/UP_Runner.py
@@ -269,7 +269,9 @@ class UP_Runner(TAF_Runner):
                 ,lower('{file}') as src_fil_type
                 ,{file}_FIL_DT as src_fil_dt
                 ,DA_RUN_ID AS SRC_DA_RUN_ID
-                ,fil_cret_dt as src_fil_creat_dt
+                ,to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
+                ,null as REC_UPDT_TS
             FROM max_run_id_{file}_{inyear}
         """
         self.prepend(z)


### PR DESCRIPTION
  In taf_ann_inp_src, adds rec_add_ts and rec_updt_ts
  In taf_ann_inp_src, sets src_fil_creat_dt to mm/dd/yyyy
  In job_cntl_parms, fil_type is lower case
  In several metadata tables, ITERATION is used over VERSION

## What is this and why are we doing it?
In the last run of TAF, metadata was generated for the first time. In examining the metadata, several issues were identified and this PR addresses them.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-3603


## What are the security implications from this change?
This is a PR that primarily addresses formatting bugs in the TAF metadata. This does not expose anything else in our data that is not currently exposed.

## How did I test this?
Generated SQL for an annual and non-annual type and examined output

## Should there be new or updated documentation for this change? (Be specific.)


## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
