### PR TITLE
Doing a casefold() and lower() check on SQL where clause for metadata

### DIFF
--- a/taf/TAF_Runner.py
+++ b/taf/TAF_Runner.py
@@ -643,6 +643,9 @@ class TAF_Runner():
         """
         spark = SparkSession.getActiveSession()
 
+        # We're matching pgm_name and step_name with casefold() params so we can
+        # ignore any case issues since this ultimately comes from user input in the
+        # job runner notebook.
         df = spark.sql(f"""
             SELECT *
             FROM {tmp_view_nm}
@@ -654,7 +657,7 @@ class TAF_Runner():
 
         for i in dict_audt:
             rstr = hash(time.time())
-            
+
             spark.sql(f"""
                 CREATE OR REPLACE TEMPORARY VIEW row_count_{rstr} AS
                 SELECT da_run_id


### PR DESCRIPTION
## What is this and why are we doing it?
Metadata that gets run after each File Type was having issues with case on field lookups. I've modified the query to do a lower() = field.casefold() to make sure we always match on lowercase. I've also had to modify the dict get statements to lowercase.


* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-3581


## What are the security implications from this change?
No impact. These are case changes to the queries and any infomation that gets created is a temporary view.


## How did I test this?
Running the JOB Runners locally using the Databricks plugin and verifying code change results


## Should there be new or updated documentation for this change? (Be specific.). Yes. The code is also commented within the file to explain why we did this.



## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
