### PR TITLE
MACDC-3603 Fix date formatting for src_fil_creat_dt

### DIFF
--- a/taf/APL/APL.py
+++ b/taf/APL/APL.py
@@ -587,7 +587,7 @@ class APL(TAF):
                 ,'{self.apl.YEAR}' as rptg_prd
                 ,'{self.apl.ITERATION}' as itrtn_num
                 ,&rowcount. as tot_rec_cnt
-                ,to_char(date(c.rec_add_ts),'MM/DD/YYYY') as fil_cret_dt
+                ,date_format(date(c.rec_add_ts),'MM/dd/yyyy') as fil_cret_dt
                 ,submtg_state_cd as incldd_state_cd
                 ,rowcount_state as rec_cnt_by_state_cd
                 ,'{self.apl.YEAR}' as fil_dt

--- a/taf/APL/APL_Runner.py
+++ b/taf/APL/APL_Runner.py
@@ -191,7 +191,7 @@ class APL_Runner(TAF_Runner):
                 '{file.lower()}' as src_fil_type,
                 {file}_fil_dt as src_fil_dt,
                 da_run_id as src_da_run_id,
-                to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt,
+                date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt,
                 from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                 null as REC_UPDT_TS
 

--- a/taf/APR/APR.py
+++ b/taf/APR/APR.py
@@ -534,7 +534,7 @@ class APR(TAF):
                 ,'{self.apr.YEAR}' as rptg_prd
                 ,'{self.apr.ITERATION}' as itrtn_num
                 ,&rowcount. as tot_rec_cnt
-                ,to_char(date(c.rec_add_ts),'MM/DD/YYYY') as fil_cret_dt
+                ,date_format(date(c.rec_add_ts),'MM/dd/yyyy') as fil_cret_dt
                 ,submtg_state_cd as incldd_state_cd
                 ,rowcount_state as rec_cnt_by_state_cd
                 ,'{self.apr.YEAR}' as fil_dt

--- a/taf/APR/APR_Runner.py
+++ b/taf/APR/APR_Runner.py
@@ -201,7 +201,7 @@ class APR_Runner(TAF_Runner):
                 lower('{file}') as src_fil_type,
                 {file}_FIL_DT as src_fil_dt,
                 DA_RUN_ID as SRC_DA_RUN_ID,
-                to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt,
+                date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt,
                 from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                 null as REC_UPDT_TS
 

--- a/taf/DE/DE_Runner.py
+++ b/taf/DE/DE_Runner.py
@@ -286,7 +286,7 @@ class DE_Runner(TAF_Runner):
                 ,lower('{file}') as src_fil_type
                 ,{file}_FIL_DT as src_fil_dt
                 ,DA_RUN_ID AS SRC_DA_RUN_ID
-                ,to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt
+                ,date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,null as REC_UPDT_TS
             FROM max_run_id_{file}_{inyear}

--- a/taf/UP/UP_Runner.py
+++ b/taf/UP/UP_Runner.py
@@ -269,7 +269,7 @@ class UP_Runner(TAF_Runner):
                 ,lower('{file}') as src_fil_type
                 ,{file}_FIL_DT as src_fil_dt
                 ,DA_RUN_ID AS SRC_DA_RUN_ID
-                ,to_char(date(fil_cret_dt),'MM/DD/YYYY') as src_fil_creat_dt
+                ,date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,null as REC_UPDT_TS
             FROM max_run_id_{file}_{inyear}


### PR DESCRIPTION
## What is this and why are we doing it?
This is a bug fix for a bug introduced in https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/commit/65337715e68cdafc393a8e33ea481b738a44f6fa

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-3603


## What are the security implications from this change?
This is changing date formatting and does not expose any new data and does not affect infrastructure.

## How did I test this?
https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/4252944469406616/command/4252944469406618
Generated sql and mocked test data in this notebook.

## Should there be new or updated documentation for this change? (Be specific.)


## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
