### PR TITLE
DBDAART-4556 Incorrect Race Codes and Flag

### DIFF
--- a/taf/BSF/BSF_Metadata.py
+++ b/taf/BSF/BSF_Metadata.py
@@ -807,6 +807,13 @@ class BSF_Metadata:
             else upper(nullif(trim({alias}.IMGRTN_STUS_CD),'')) end as IMGRTN_STUS_CD
         """
 
+    def cleanRaceCd(alias):
+        """
+        Clean race code values by left padding to a total length of 3 characters.
+        """
+
+        return f"lpad(trim({alias}.race_cd), 3, '0') AS race_cd"
+
     # ---------------------------------------------------------------------------------
     #
     #  'C' Chinese
@@ -919,7 +926,8 @@ class BSF_Metadata:
         'PRMRY_LANG_CD': cleanPrimaryLangCd,
         'DSBLTY_TYPE_CD': cleanDisabilityTypeCd,
         'NDC_UOM_CHRNC_NON_HH_CD': cleanNDC_UOM_CHRNC_NON_HH_CD,
-        'IMGRTN_STUS_CD': cleanImmigrationStatusCd
+        'IMGRTN_STUS_CD': cleanImmigrationStatusCd,
+        'RACE_CD': cleanRaceCd,
     }
 
     absent = [

--- a/taf/__init__.py
+++ b/taf/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "PI03.04"
+__version__ = "PI04.01"


### PR DESCRIPTION
## What is this and why are we doing it?
While reviewing the results of the September 2023 TAF run in DataConnect, discrepancies related to derived race and ethnicity information were discovered in the monthly Beneficiary summary data. The root cause of the issue was determined to be the absence of a "cleanser" definition to transform race code values to be padded with zeroes (consistent with several other code values). As a result, downstream indicators and flags were not assigned correctly. This change adds a "cleanser" specific to race codes to remediate impacted columns and their corresponding values.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4556


## What are the security implications from this change?
This change should not introduce any new security implications as we are transforming a value from T-MSIS data.

## How did I test this?
I tested this change by generating SQL for the impacted segment in my local development environment and comparing to September's run. I then built and deployed updates to the E2 VAL environment and generated a month of new Beneficiary summary data [here](https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#job/249874606467702/run/855683453805811). The run was successful and record counts match the same run from the Production Redshift environment. Results [here](https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/2954692310779669/command/2954692310779670).

SQL before change:
```
CREATE
	OR replace TEMPORARY VIEW ELG00016 AS

SELECT a.TMSIS_RUN_ID
	,a.TMSIS_ACTV_IND
	,a.SUBMTG_STATE_CD
	,a.REC_NUM
	,a.RACE_CD
```

SQL after change:
```
CREATE
	OR replace TEMPORARY VIEW ELG00016 AS

SELECT a.TMSIS_RUN_ID
	,a.TMSIS_ACTV_IND
	,a.SUBMTG_STATE_CD
	,a.REC_NUM
	,lpad(trim(a.race_cd), 3, '0') AS race_cd
```

## Should there be new or updated documentation for this change? (Be specific.)
No changes to documentation are necessary at this point.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
