### PR TITLE
DBDAART-4555 Fix reference to Care Level Status

### DIFF
--- a/taf/BSF/BSF_Metadata.py
+++ b/taf/BSF/BSF_Metadata.py
@@ -468,7 +468,7 @@ class BSF_Metadata:
                         t1.ELGBL_ZIP_CD_MAIL,
                         t1.ELGBL_CNTY_CD_MAIL,
                         t1.ELGBL_STATE_CD_MAIL,
-                        t1.CARE_LVL_STUS_CD,
+                        t1.CARE_LVL_STUS_CODE as CARE_LVL_STUS_CD,
                         t1.DEAF_DISAB_FLAG as DEAF_DSBL_FLAG,
                         t1.BLIND_DISAB_FLAG as BLND_DSBL_FLAG,
                         t1.DIFF_CONC_DISAB_FLAG as DFCLTY_CONC_DSBL_FLAG,

--- a/taf/__init__.py
+++ b/taf/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "PI04.01"
+__version__ = "PI04.02"


### PR DESCRIPTION
## What is this and why are we doing it?
While reviewing the results of the September 2023 TAF run in DataConnect, discrepancies related to care level status codes were discovered in the monthly Beneficiary summary data. The root cause of the issue was determined to be writing the incorrect column value to the final Beneficiary summary table. As a result, downstream indicators and flags were not assigned correctly. This change writes the correct, zero padded value to the final Beneficiary summary table.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4555


## What are the security implications from this change?
This change should not introduce any new security implications as we are transforming a value from T-MSIS data.


## How did I test this?
I tested this change by generating SQL for the impacted segment in my local development environment and comparing to September's run. I then built and deployed updates to the E2 VAL environment and generated a month of new Beneficiary summary data [here](https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#job/249874606467702/run/855683453805811). The run was successful and record counts match the same run from the Production Redshift environment. Results [here](https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/2954692310779669/command/2954692310779670).

SQL before change:
```
CREATE
	OR replace BSF_STEP1 AS

SELECT ...
        t1.CARE_LVL_STUS_CD,
```

SQL after change:
```
CREATE
	OR replace BSF_STEP1 AS

SELECT ...
        t1.CARE_LVL_STUS_CODE as CARE_LVL_STUS_CD,
```


## Should there be new or updated documentation for this change? (Be specific.)
No changes to documentation are necessary at this point.


## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation