### PR TITLE
DBDAART-3603 Set job_cntl_parms job_parms_txt to last day of month

### DIFF
--- a/taf/TAF_Runner.py
+++ b/taf/TAF_Runner.py
@@ -55,6 +55,7 @@ class TAF_Runner():
         self.DA_RUN_ID = job_id
         self.DA_SCHEMA = da_schema  # For using data from Redshift for testing DE and up
 
+        self.reporting_period_parameter = reporting_period
         self.reporting_period = datetime.strptime(reporting_period, '%Y-%m-%d')
 
         begmon = self.reporting_period
@@ -316,9 +317,9 @@ class TAF_Runner():
         spark = SparkSession.getActiveSession()
 
         if (self.national_run):
-            parms = f"{self.st_dt}"
+            parms = f"{self.reporting_period_parameter}"
         else:
-            parms = f"{self.st_dt}" + ", " + "submtg_state_cd" + " " + "in" + " " + "(" + f"{self.state_code}" + ")"
+            parms = f"{self.reporting_period_parameter}" + ", " + "submtg_state_cd" + " " + "in" + " " + "(" + f"{self.state_code}" + ")"
 
         insert_query = f"""
             INSERT INTO {self.DA_SCHEMA}.job_cntl_parms (


### PR DESCRIPTION
## What is this and why are we doing it?
This is changing job_cntl_parms.job_parms_txt to use the last day of the month. The purpose of this is to match TAF in Redshift. Since the last day of the month is specified when doing job runs, this parameter can be used to insert into job_cntl_parms.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-3603


## What are the security implications from this change?
No new data is exposed from this change.

## How did I test this?
https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#job/110491103788104/run/355360875546544
This run is executing metadata for da_run_id 9607. Looking at the job_cntl_parms after the run shows that job_parms_txt is 2023-06-30.

## Should there be new or updated documentation for this change? (Be specific.)


## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
