### PR TITLE
[DBDAART-4516] Update CODEOWNERS Remove old accounts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @C1KB-tensileai @FICU-tensileai @AKDO-slalom @THOA-slalom @GPEC-adhoc @TUAS-forpeople @BKY3-forpeople @VPAI-bixal @TBWM-slalom @MIPI-forpeople @GHHZ-bixal @RIE9-adhoc
+* @C1KB-tensileai @FICU-tensileai @AKDO-slalom @THOA-slalom @GPEC-adhoc @TUAS-forpeople @BKY3-forpeople @VPAI-bixal @MIPI-forpeople @GHHZ-bixal @RIE9-adhoc


### PR DESCRIPTION
## What is this and why are we doing it?
As part of larger on/offboarding discussions and review, it was discovered that offboarded people haven't been removed from CODEOWNERS files in the macdc repos.

This story is to review all macdc CODEOWNERS files and remove anyone not on the project.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4516


## What are the security implications from this change?
Removing accounts no longer on project improves security.

## How did I test this?
na

## Should there be new or updated documentation for this change? (Be specific.)
just the jira ticket

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
