### PR TITLE
Fix Null Adj Indicators

### DIFF
--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -78,7 +78,10 @@ class LT_Metadata:
         "DGNS_4_CD": TAF_Closure.compress_dots,
         "DGNS_5_CD": TAF_Closure.compress_dots,
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
-        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD
+        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
+        "ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
+        "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND
+
     }
 
     validator = {}
@@ -371,14 +374,12 @@ class LT_Metadata:
     upper = [
         "ADJSTMT_LINE_NUM",
         "ADJSTMT_LINE_RSN_CD",
-        "ADJSTMT_IND",
         "BLG_UNIT_CD",
         "BNFT_TYPE_CD",
         "CLL_STUS_CD",
         "CMS_64_FED_REIMBRSMT_CTGRY_CD",
         "HCPCS_RATE",
         "IMNZTN_TYPE_CD",
-        "LINE_ADJSTMT_IND",
         "MSIS_IDENT_NUM",
         "NDC_CD",
         "NDC_UOM_CD",


### PR DESCRIPTION
## What is this and why are we doing it?
2 records in LTH were getting dropped and I traced it to null adjustment indicators not being coalesced with X on extract.   LTH did not do this but the other 3 claims file types did.   To fix, in LT_Metadata.py I removed adjustment indicator and line adjustment indicator from the upper list, and added them to the cleanser list, invoking cleanAdjustmentInd function (matching other claims file types).

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-4578

## What are the security implications from this change?
None

## How did I test this?
visual inspection of Before/After SQL (attached to ticket).   Visual comparison to other claim types & SAS.


## Should there be new or updated documentation for this change? (Be specific.)
No.

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ N/a] I have made corresponding changes to the documentation
