### PR TITLE
DBDAART-4575 PRV & APR prvdr_id long values

### DIFF
--- a/taf/PRV/PRV05.py
+++ b/taf/PRV/PRV05.py
@@ -118,7 +118,7 @@ class PRV05(PRV):
                     submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
                     prov_location_id as PRVDR_LCTN_ID,
                     PRVDR_ID_TYPE_CD,
-                    cast(prov_identifier as varchar(12)) as PRVDR_ID,
+                    substr(prov_identifier from 1 for 12) as PRVDR_ID,
                     prov_identifier_issuing_entity_id as PRVDR_ID_ISSG_ENT_ID_TXT,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     cast(NULL as timestamp) as REC_UPDT_TS

--- a/taf/PRV/PRV08.py
+++ b/taf/PRV/PRV08.py
@@ -96,7 +96,7 @@ class PRV08(PRV):
                     tms_run_id as TMSIS_RUN_ID,
                     SUBMTG_STATE_CD,
                     submitting_state_prov_id as SUBMTG_STATE_PRVDR_ID,
-                    cast (submitting_state_prov_id_of_affiliated_entity as varchar(12)) as SUBMTG_STATE_AFLTD_PRVDR_ID,
+                    substr(submitting_state_prov_id_of_affiliated_entity from 1 for 12) as SUBMTG_STATE_AFLTD_PRVDR_ID,
                     from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                     cast(NULL as timestamp) as REC_UPDT_TS
                     from Prov08_Groups


### PR DESCRIPTION
## What is this and why are we doing it?
to address the issue of long provider ID values, greater than 12 characters, in the PRV & APR Identity & Group segments

* Link to the Jira ticket for this change:  
<https://jiraent.cms.gov/browse/DBDAART-4575>

## What are the security implications from this change?
none

## How did I test this?
notebook in databricks VAL

## Should there be new or updated documentation for this change? (Be specific.)
no

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
