### PR TITLE
DBDAART-4731 Add upper case flag to tooth numbers

### DIFF
--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -70,7 +70,7 @@ class OTL:
                 , { TAF_Closure.var_set_prtype('SRVCNG_PRVDR_TYPE_CD') }
                 , { TAF_Closure.var_set_spclty('SRVCNG_PRVDR_SPCLTY_CD') }
                 , { TAF_Closure.var_set_type4('TOOTH_DSGNTN_SYS_CD', 'YES', cond1='JO', cond2='JP') }
-                , { TAF_Closure.var_set_type1('TOOTH_NUM') }
+                , { TAF_Closure.var_set_type1('TOOTH_NUM', upper=True) }
                 , case when lpad(upper(TOOTH_ORAL_CVTY_AREA_DSGNTD_CD), 2, '0') in ('20', '30', '40') then lpad(upper(TOOTH_ORAL_CVTY_AREA_DSGNTD_CD), 2, '0')
                     else { TAF_Closure.var_set_type5('TOOTH_ORAL_CVTY_AREA_DSGNTD_CD', lpad=2, lowerbound=0, upperbound=10, multiple_condition='YES', upper=True) }
                 , { TAF_Closure.var_set_type4('TOOTH_SRFC_CD', 'YES', cond1='B', cond2='D', cond3='F', cond4='I', cond5='L', cond6='M', cond7='O') }


### PR DESCRIPTION
## What is this and why are we doing it?
Reviewing results of the FFC of September's interim TAF run in DC, we noticed `TOOTH_NUM` values written to the Outpatient/Other claim lines file were no longer uppercase. This was previously addressed under [MACDC-5742](https://cms-dataconnect.atlassian.net/browse/MACDC-5743). Further investigation yielded that the `upper` flag was removed in the call to `var_set_type1` for `TOOTH_NUM` by [this](https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/commit/6d8fe95ed345296714c44cfc23c911cd7265a7c2) commit. This change reverts impacted ETL for `TOOTH_NUM`



* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4731


## What are the security implications from this change?
There are no new security implications from this change as this change transforms values from a existing query.

## How did I test this?
I generated the SQL to create Outpatient/Other claim lines before and after my fix. Comparing the differences, we can see that `TOOTH_NUM` is being written as a uppercase value as expected.

Before change:
```
(.venv) scleeton@BLD:/mnt/e/Projects/T-MSIS-Analytic-File-Generation-Python/test/integration_testing/OT$ more test_otl_before.sql | grep TOOTH_NUM
                        ,a.TOOTH_NUM
                , trim(TOOTH_NUM)
    as TOOTH_NUM
                        ,TOOTH_NUM
```

After change:
```
(.venv) scleeton@BLD:/mnt/e/Projects/T-MSIS-Analytic-File-Generation-Python/test/integration_testing/OT$ more otl_test.sql | grep TOOTH_NUM
                        ,a.TOOTH_NUM
                , trim(upper(TOOTH_NUM))
    as TOOTH_NUM
                        ,TOOTH_NUM
```

## Should there be new or updated documentation for this change? (Be specific.)
No changes to documentation needed since this change previously existed in our code base.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


[MACDC-5742]: https://cms-dataconnect.atlassian.net/browse/MACDC-5742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ