### PR TITLE
DBAART-4762 Fix DE Link Key

### DIFF
--- a/taf/DE/DE_Runner.py
+++ b/taf/DE/DE_Runner.py
@@ -60,7 +60,7 @@ class DE_Runner(TAF_Runner):
         self.NWAIVSLOTS: int = 10
         self.MONTHSB = ["12", "11", "10", "09", "08", "07", "06", "05", "04", "03", "02", "01"]
         self.RUNDATE = ""
-        self.VERSION: int = 0
+        # self.VERSION: int = 0
         # self.DA_RUN_ID: int = run_id
         self.ROWCOUNT: int = 0
         self.TMSIS_SCHEMA = "TMSIS"


### PR DESCRIPTION
commenting out assignment of VERSION to 0 which leads to incorrect values in the DE_LINK_KEY field https://jiraent.cms.gov/browse/DBDAART-4762

## What is this and why are we doing it?
to fix a bug in DE_LINK_KEY and ANN_DE_VRSN

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4762


## What are the security implications from this change?
no

## How did I test this?
initial investigation performed here: https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/2956054267841356
and another ticket, [DBAART-4787](https://jiraent.cms.gov/browse/DBAART-4787),has been opened to determine if further investigation is necessary

## Should there be new or updated documentation for this change? (Be specific.)
no

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
