### PR TITLE
DBDAART-4580 Incorrect Claim Aggregation in Use and Payment File

### DIFF
--- a/taf/UP/BASE_HDR_COMB.py
+++ b/taf/UP/BASE_HDR_COMB.py
@@ -46,7 +46,7 @@ class BASE_HDR_COMB(UP):
                 z += f"""
                      ,{ TAF_Closure.getmax(incol=f"{ind1}_rcpnt_{ind2}_FFS_FLAG") }
                      ,{ TAF_Closure.getmax(incol=f"{ind1}_rcpnt_{ind2}_MC_FLAG") }
-                     ,{ TAF_Closure.getmax(incol=f"TOT_{ind1}_{ind2}_PD") }
+                     ,{ TAF_Closure.sumrecs(incol=f"TOT_{ind1}_{ind2}_PD") }
                 """
 
                 if ind2.casefold() == "non_xovr":

--- a/taf/__init__.py
+++ b/taf/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "PI04.02"
+__version__ = "PI04.03"


### PR DESCRIPTION
## What is this and why are we doing it?
While reviewing the results of the September 2023 TAF run in DataConnect, discrepancies with claim paid amounts were discovered in the annual Use and Payment data. The root cause of the issue was determined to be that the incorrect aggregation function was passed to the `TAF_Closure` definition. In this case, each claim type (IP, OT, LT, and RX) are combined using the maximum claim paid value rather than the summation of all types.


* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4580


## What are the security implications from this change?
This change should not introduce any new security implications as we are transforming a value from T-MSIS data.

## How did I test this?
A new wheel was built and deployed to [re-create](https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#job/202767374103997/run/81263759256360) September 2023's Use and Payment data. After that, the Full File Comparison was run and [results](https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#job/1122068132872290/run/634792293522875) indicated the change was successful since we agree with production data.

## Should there be new or updated documentation for this change? (Be specific.)
No changes to documentation are necessary at this point.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
