### PR TITLE
Modified dates for python coalesce 01-01-1960

### DIFF
--- a/taf/IP/IPL.py
+++ b/taf/IP/IPL.py
@@ -38,7 +38,7 @@ class IPL:
                 , { TAF_Closure.var_set_type1('ORGNL_LINE_NUM') }
                 , { TAF_Closure.var_set_type1('ADJSTMT_LINE_NUM') }
 
-                , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE,'01-01-1960') end as ADJDCTN_DT
+                , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE,'1960-01-01') end as ADJDCTN_DT
                 ,LINE_ADJSTMT_IND_CLEAN as LINE_ADJSTMT_IND
 
                 , { TAF_Closure.var_set_tos('TOS_CD') }
@@ -52,8 +52,8 @@ class IPL:
 
                 , { TAF_Closure.var_set_type1('CLL_STUS_CD') }
 
-                , case when (SRVC_BGNNG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_BGNNG_DT, '01-01-1960') end as SRVC_BGNNG_DT
-                , case when (SRVC_ENDG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_ENDG_DT, '01-01-1960') end as SRVC_ENDG_DT
+                , case when (SRVC_BGNNG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_BGNNG_DT, '1960-01-01') end as SRVC_BGNNG_DT
+                , case when (SRVC_ENDG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_ENDG_DT, '1960-01-01') end as SRVC_ENDG_DT
 
                 , { TAF_Closure.var_set_type5('BNFT_TYPE_CD', lpad=3, lowerbound='001', upperbound='108') }
                 , { TAF_Closure.var_set_type1('REV_CD', lpad=4) }

--- a/taf/IP/IPL.py
+++ b/taf/IP/IPL.py
@@ -38,7 +38,7 @@ class IPL:
                 , { TAF_Closure.var_set_type1('ORGNL_LINE_NUM') }
                 , { TAF_Closure.var_set_type1('ADJSTMT_LINE_NUM') }
 
-                , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE,'1960-01-01') end as ADJDCTN_DT
+                , case when (ADJDCTN_DT_LINE < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(ADJDCTN_DT_LINE,'01-01-1960') end as ADJDCTN_DT
                 ,LINE_ADJSTMT_IND_CLEAN as LINE_ADJSTMT_IND
 
                 , { TAF_Closure.var_set_tos('TOS_CD') }
@@ -52,8 +52,8 @@ class IPL:
 
                 , { TAF_Closure.var_set_type1('CLL_STUS_CD') }
 
-                , case when (SRVC_BGNNG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_BGNNG_DT, '01JAN1960') end as SRVC_BGNNG_DT
-                , case when (SRVC_ENDG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_ENDG_DT, '01JAN1960') end as SRVC_ENDG_DT
+                , case when (SRVC_BGNNG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_BGNNG_DT, '01-01-1960') end as SRVC_BGNNG_DT
+                , case when (SRVC_ENDG_DT < to_date('1600-01-01')) then to_date('1599-12-31') else nullif(SRVC_ENDG_DT, '01-01-1960') end as SRVC_ENDG_DT
 
                 , { TAF_Closure.var_set_type5('BNFT_TYPE_CD', lpad=3, lowerbound='001', upperbound='108') }
                 , { TAF_Closure.var_set_type1('REV_CD', lpad=4) }

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -57,7 +57,7 @@ class IP_Metadata:
 
     def dates_of_service(colname: str, alias: str):
         """
-        Return dates of service.  If column name is null, then set date to 01JAN1960.
+        Return dates of service.  If column name is null, then set date to 1960-01-01.
         """
 
         return f"""
@@ -66,7 +66,7 @@ class IP_Metadata:
                 when {alias}.{colname} is not null then '1'
                 else null
             end as SRVC_ENDG_DT_CD_H,
-            coalesce({alias}.{colname}, '01-01-1960') as {colname}
+            coalesce({alias}.{colname}, '1960-01-01') as {colname}
         """
 
     def plan_id_num(colname: str, alias: str):
@@ -355,11 +355,11 @@ class IP_Metadata:
     }
 
     coalesce = {
-        "ADJDCTN_DT": "01-01-1960",
-        "ADJDCTN_DT": "01-01-1960",
-        "DSCHRG_DT": "01-01-1960",
-        "SRVC_BGNNG_DT": "01-01-1960",
-        "SRVC_ENDG_DT": "01-01-1960",
+        "ADJDCTN_DT": "1960-01-01",
+        "ADJDCTN_DT": "1960-01-01",
+        "DSCHRG_DT": "1960-01-01",
+        "SRVC_BGNNG_DT": "1960-01-01",
+        "SRVC_ENDG_DT": "1960-01-01",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -66,7 +66,7 @@ class IP_Metadata:
                 when {alias}.{colname} is not null then '1'
                 else null
             end as SRVC_ENDG_DT_CD_H,
-            coalesce({alias}.{colname}, '01JAN1960') as {colname}
+            coalesce({alias}.{colname}, '01-01-1960') as {colname}
         """
 
     def plan_id_num(colname: str, alias: str):
@@ -355,11 +355,11 @@ class IP_Metadata:
     }
 
     coalesce = {
-        "ADJDCTN_DT": "01JAN1960",
-        "ADJDCTN_DT": "01JAN1960",
-        "DSCHRG_DT": "01JAN1960",
-        "SRVC_BGNNG_DT": "01JAN1960",
-        "SRVC_ENDG_DT": "01JAN1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "DSCHRG_DT": "01-01-1960",
+        "SRVC_BGNNG_DT": "01-01-1960",
+        "SRVC_ENDG_DT": "01-01-1960",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -38,16 +38,16 @@ class LTH:
                 , { TAF_Closure.var_set_rsn('ADJSTMT_RSN_CD') }
                 , case
                     when (SRVC_BGNNG_DT < '1600-01-01') then '1599-12-31'
-                    else nullif(SRVC_BGNNG_DT, '1960-01-01')
+                    else nullif(SRVC_BGNNG_DT, '01-01-1960')
                   end as SRVC_BGNNG_DT
-                , nullif(SRVC_ENDG_DT, '1960-01-01') as SRVC_ENDG_DT
+                , nullif(SRVC_ENDG_DT, '01-01-1960') as SRVC_ENDG_DT
                 , { TAF_Closure.fix_old_dates('ADMSN_DT') }
                 , { TAF_Closure.var_set_type5(var='ADMSN_HR_NUM', lpad=2, lowerbound=0, upperbound=23) }
                 , { TAF_Closure.fix_old_dates('DSCHRG_DT') }
                 , { TAF_Closure.var_set_type5(var='DSCHRG_HR_NUM', lpad=2, lowerbound=0, upperbound=23) }
                 , case
                     when ADJDCTN_DT < '1600-01-01' then '1599-12-31'
-                    else nullif(ADJDCTN_DT, '1960-01-01')
+                    else nullif(ADJDCTN_DT, '01-01-1960')
                   end as ADJDCTN_DT
                 , { TAF_Closure.fix_old_dates('MDCD_PD_DT') }
                 , { TAF_Closure.var_set_type2(var='SECT_1115A_DEMO_IND', lpad=0, cond1='0', cond2='1') }

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -38,16 +38,16 @@ class LTH:
                 , { TAF_Closure.var_set_rsn('ADJSTMT_RSN_CD') }
                 , case
                     when (SRVC_BGNNG_DT < '1600-01-01') then '1599-12-31'
-                    else nullif(SRVC_BGNNG_DT, '01-01-1960')
+                    else nullif(SRVC_BGNNG_DT, '1960-01-01')
                   end as SRVC_BGNNG_DT
-                , nullif(SRVC_ENDG_DT, '01-01-1960') as SRVC_ENDG_DT
+                , nullif(SRVC_ENDG_DT, '1960-01-01') as SRVC_ENDG_DT
                 , { TAF_Closure.fix_old_dates('ADMSN_DT') }
                 , { TAF_Closure.var_set_type5(var='ADMSN_HR_NUM', lpad=2, lowerbound=0, upperbound=23) }
                 , { TAF_Closure.fix_old_dates('DSCHRG_DT') }
                 , { TAF_Closure.var_set_type5(var='DSCHRG_HR_NUM', lpad=2, lowerbound=0, upperbound=23) }
                 , case
                     when ADJDCTN_DT < '1600-01-01' then '1599-12-31'
-                    else nullif(ADJDCTN_DT, '01-01-1960')
+                    else nullif(ADJDCTN_DT, '1960-01-01')
                   end as ADJDCTN_DT
                 , { TAF_Closure.fix_old_dates('MDCD_PD_DT') }
                 , { TAF_Closure.var_set_type2(var='SECT_1115A_DEMO_IND', lpad=0, cond1='0', cond2='1') }

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -328,10 +328,10 @@ class LT_Metadata:
         }
 
     coalesce = {
-        "ADJDCTN_DT": "01-01-1960",
-        "ADJDCTN_DT_LINE": "01-01-1960",
-        "SRVC_BGNNG_DT": "01-01-1960",
-        "SRVC_ENDG_DT": "01-01-1960",
+        "ADJDCTN_DT": "1960-01-01",
+        "ADJDCTN_DT_LINE": "1960-01-01",
+        "SRVC_BGNNG_DT": "1960-01-01",
+        "SRVC_ENDG_DT": "1960-01-01",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -328,10 +328,10 @@ class LT_Metadata:
         }
 
     coalesce = {
-        "ADJDCTN_DT": "01JAN1960",
-        "ADJDCTN_DT_LINE": "01JAN1960",
-        "SRVC_BGNNG_DT": "01JAN1960",
-        "SRVC_ENDG_DT": "01JAN1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "ADJDCTN_DT_LINE": "01-01-1960",
+        "SRVC_BGNNG_DT": "01-01-1960",
+        "SRVC_ENDG_DT": "01-01-1960",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -78,7 +78,7 @@ class OT_Metadata:
 
     def dates_of_service(colname: str, alias: str):
         """
-        Return dates of service.  If column name is null, then set date to 01JAN1960.
+        Return dates of service.  If column name is null, then set date to 1960-01-01.
         """
 
         return f"""
@@ -88,7 +88,7 @@ class OT_Metadata:
                 when {alias}.{colname} is null and {alias}.SRVC_BGNNG_DT is not null then '3'
                 else null
             end as SRVC_ENDG_DT_CD_H,
-            coalesce({alias}.{colname}, '01-01-1960') as {colname}
+            coalesce({alias}.{colname}, '1960-01-01') as {colname}
         """
 
     def line_dates_of_service(colname: str, alias: str):
@@ -336,11 +336,11 @@ class OT_Metadata:
         }
 
     coalesce = {
-        "ADJDCTN_DT": "01-01-1960",
-        "ADJDCTN_DT": "01-01-1960",
-        "DSCHRG_DT": "01-01-1960",
-        "SRVC_BGNNG_DT": "01-01-1960",
-        "SRVC_ENDG_DT": "01-01-1960",
+        "ADJDCTN_DT": "1960-01-01",
+        "ADJDCTN_DT": "1960-01-01",
+        "DSCHRG_DT": "1960-01-01",
+        "SRVC_BGNNG_DT": "1960-01-01",
+        "SRVC_ENDG_DT": "1960-01-01",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -88,7 +88,7 @@ class OT_Metadata:
                 when {alias}.{colname} is null and {alias}.SRVC_BGNNG_DT is not null then '3'
                 else null
             end as SRVC_ENDG_DT_CD_H,
-            coalesce({alias}.{colname}, '01JAN1960') as {colname}
+            coalesce({alias}.{colname}, '01-01-1960') as {colname}
         """
 
     def line_dates_of_service(colname: str, alias: str):
@@ -336,11 +336,11 @@ class OT_Metadata:
         }
 
     coalesce = {
-        "ADJDCTN_DT": "01JAN1960",
-        "ADJDCTN_DT": "01JAN1960",
-        "DSCHRG_DT": "01JAN1960",
-        "SRVC_BGNNG_DT": "01JAN1960",
-        "SRVC_ENDG_DT": "01JAN1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "DSCHRG_DT": "01-01-1960",
+        "SRVC_BGNNG_DT": "01-01-1960",
+        "SRVC_ENDG_DT": "01-01-1960",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/RX/RX_Metadata.py
+++ b/taf/RX/RX_Metadata.py
@@ -209,11 +209,11 @@ class RX_Metadata:
         }
 
     coalesce = {
-        "ADJDCTN_DT": "01JAN1960",
-        "ADJDCTN_DT": "01JAN1960",
-        "DSCHRG_DT": "01JAN1960",
-        "SRVC_BGNNG_DT": "01JAN1960",
-        "SRVC_ENDG_DT": "01JAN1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "ADJDCTN_DT": "01-01-1960",
+        "DSCHRG_DT": "01-01-1960",
+        "SRVC_BGNNG_DT": "01-01-1960",
+        "SRVC_ENDG_DT": "01-01-1960",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/RX/RX_Metadata.py
+++ b/taf/RX/RX_Metadata.py
@@ -209,11 +209,11 @@ class RX_Metadata:
         }
 
     coalesce = {
-        "ADJDCTN_DT": "01-01-1960",
-        "ADJDCTN_DT": "01-01-1960",
-        "DSCHRG_DT": "01-01-1960",
-        "SRVC_BGNNG_DT": "01-01-1960",
-        "SRVC_ENDG_DT": "01-01-1960",
+        "ADJDCTN_DT": "1960-01-01",
+        "ADJDCTN_DT": "1960-01-01",
+        "DSCHRG_DT": "1960-01-01",
+        "SRVC_BGNNG_DT": "1960-01-01",
+        "SRVC_ENDG_DT": "1960-01-01",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_CLM_NUM": "~",
         "ADJSTMT_IND": "X",

--- a/taf/TAF_Claims.py
+++ b/taf/TAF_Claims.py
@@ -272,7 +272,7 @@ class TAF_Claims():
                             H.SUBMTG_STATE_CD = L.SUBMTG_STATE_CD and
                             H.ORGNL_CLM_NUM = upper(coalesce(L.ORGNL_CLM_NUM,'~')) and
                             H.ADJSTMT_CLM_NUM = upper(coalesce(L.ADJSTMT_CLM_NUM,'~')) and
-                            H.ADJDCTN_DT = coalesce(L.ADJDCTN_DT,'01-01-1960') and
+                            H.ADJDCTN_DT = coalesce(L.ADJDCTN_DT,'1960-01-01') and
                             H.ADJSTMT_IND = upper(coalesce(L.LINE_ADJSTMT_IND,'X'))
 
                         where
@@ -407,14 +407,14 @@ class TAF_Claims():
                         B.ADJDCTN_DT,
                         upper(B.ADJSTMT_IND) as ADJSTMT_IND,
                         case
-                            when nullif(B.SRVC_ENDG_DT, '01-01-1960') is null
+                            when nullif(B.SRVC_ENDG_DT, '1960-01-01') is null
                             or SRVC_ENDG_DT is null then SRVC_BGNNG_DT
                             else SRVC_ENDG_DT
                         end as SRVC_ENDG_DT_DRVD_L,
                         case
-                            when nullif(B.SRVC_ENDG_DT, '01-01-1960') is not null
+                            when nullif(B.SRVC_ENDG_DT, '1960-01-01') is not null
                                 and SRVC_ENDG_DT is not null then '4'
-                            when nullif(B.SRVC_BGNNG_DT, '01-01-1960') is not null
+                            when nullif(B.SRVC_BGNNG_DT, '1960-01-01') is not null
                                 and SRVC_BGNNG_DT is not null then '5'
                             else null
                         end as SRVC_ENDG_DT_CD_L

--- a/taf/TAF_Claims.py
+++ b/taf/TAF_Claims.py
@@ -272,7 +272,7 @@ class TAF_Claims():
                             H.SUBMTG_STATE_CD = L.SUBMTG_STATE_CD and
                             H.ORGNL_CLM_NUM = upper(coalesce(L.ORGNL_CLM_NUM,'~')) and
                             H.ADJSTMT_CLM_NUM = upper(coalesce(L.ADJSTMT_CLM_NUM,'~')) and
-                            H.ADJDCTN_DT = coalesce(L.ADJDCTN_DT,'01JAN1960') and
+                            H.ADJDCTN_DT = coalesce(L.ADJDCTN_DT,'01-01-1960') and
                             H.ADJSTMT_IND = upper(coalesce(L.LINE_ADJSTMT_IND,'X'))
 
                         where
@@ -407,14 +407,14 @@ class TAF_Claims():
                         B.ADJDCTN_DT,
                         upper(B.ADJSTMT_IND) as ADJSTMT_IND,
                         case
-                            when nullif(B.SRVC_ENDG_DT, '01JAN1960') is null
+                            when nullif(B.SRVC_ENDG_DT, '01-01-1960') is null
                             or SRVC_ENDG_DT is null then SRVC_BGNNG_DT
                             else SRVC_ENDG_DT
                         end as SRVC_ENDG_DT_DRVD_L,
                         case
-                            when nullif(B.SRVC_ENDG_DT, '01JAN1960') is not null
+                            when nullif(B.SRVC_ENDG_DT, '01-01-1960') is not null
                                 and SRVC_ENDG_DT is not null then '4'
-                            when nullif(B.SRVC_BGNNG_DT, '01JAN1960') is not null
+                            when nullif(B.SRVC_BGNNG_DT, '01-01-1960') is not null
                                 and SRVC_BGNNG_DT is not null then '5'
                             else null
                         end as SRVC_ENDG_DT_CD_L

--- a/taf/TAF_Metadata.py
+++ b/taf/TAF_Metadata.py
@@ -1015,6 +1015,17 @@ class TAF_Metadata:
 
             subDF.createOrReplaceTempView("state_submsn_type")
 
+    # match 01JAN1960
+    @staticmethod
+    def parse_date_null(strdate: str, fuzzy: False):
+        from dateutil.parser import parse
+
+        datetime = parse(strdate, fuzzy=fuzzy)
+
+        if datetime.month == 1 and datetime.day == 1 and datetime.year == 1960:
+            return True
+        else:
+            return False
 
 # -----------------------------------------------------------------------------
 # CC0 1.0 Universal

--- a/taf/TAF_Metadata.py
+++ b/taf/TAF_Metadata.py
@@ -1015,18 +1015,6 @@ class TAF_Metadata:
 
             subDF.createOrReplaceTempView("state_submsn_type")
 
-    # match 01JAN1960
-    @staticmethod
-    def parse_date_null(strdate: str, fuzzy: False):
-        from dateutil.parser import parse
-
-        datetime = parse(strdate, fuzzy=fuzzy)
-
-        if datetime.month == 1 and datetime.day == 1 and datetime.year == 1960:
-            return True
-        else:
-            return False
-
 # -----------------------------------------------------------------------------
 # CC0 1.0 Universal
 


### PR DESCRIPTION
## What is this and why are we doing it?
Because the data was originally being parsed by SAS, a null date was showing up as 01JAN1960 (epoch for sas dates). This date wasn't the format that python is looking for to coalesce for null dates. We've changed these to the proper format of 01-01-1960 from our incoming data. Keep in mind, while reviewing, that to_date() formats still remain as 1960-01-01

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-3572


## What are the security implications from this change?
No security implications. We're just modifying date formats.


## How did I test this?
I've set up a runner for the changes IP, LT, OT, and RX and called "view_plan()" to display the generated sql showing no 01JAN1960

See attached below:
[test_IP_Runner.py_.txt](https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/files/13342607/test_IP_Runner.py_.txt)
[test_LT_Runner.py_.txt](https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/files/13342608/test_LT_Runner.py_.txt)
[test_OT_Runner.py_.txt](https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/files/13342609/test_OT_Runner.py_.txt)
[test_RX_Runner.py.txt](https://github.com/Enterprise-CMCS/T-MSIS-Analytic-File-Generation-Python/files/13342610/test_RX_Runner.py.txt)


## Should there be new or updated documentation for this change? (Be specific.)
No.


## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
