### PR TITLE
DBDAART-4820 Assign REC_UPDT_TS in Claims Header data

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -247,7 +247,7 @@ class IPH:
                 , cast(nullif(PRIMARY_HIERARCHICAL_CONDITION, PRIMARY_HIERARCHICAL_CONDITION) as char(9)) as PRMRY_HIRCHCL_COND
 
                 , from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                , cast(NULL as timestamp) as REC_UPDT_TS
+                , from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
 
                 , { TAF_Closure.fix_old_dates('SRVC_ENDG_DT_DRVD')}
                 , { TAF_Closure.var_set_type2('SRVC_ENDG_DT_CD',0,cond1='1',cond2='2',cond3='3',cond4='4',cond5='5') }

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -183,7 +183,7 @@ class LTH:
                 ,nullif(IAP_CONDITION_IND, IAP_CONDITION_IND) as IAP_COND_IND
                 ,nullif(PRIMARY_HIERARCHICAL_CONDITION, PRIMARY_HIERARCHICAL_CONDITION) as PRMRY_HIRCHCL_COND
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,cast(NULL as timestamp) as REC_UPDT_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
                 ,{ TAF_Closure.var_set_taxo('BLG_PRVDR_NPPES_TXNMY_CD',cond1='8888888888', cond2='9999999999', cond3='000000000X', cond4='999999999X',
                                                 cond5='NONE', cond6='XXXXXXXXXX', cond7='NO TAXONOMY') }
                 ,DGNS_1_CCSR_DFLT_CTGRY_CD

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -172,7 +172,7 @@ class OTH:
                 , cast(nullif(IAP_CONDITION_IND, IAP_CONDITION_IND) as char(6)) as IAP_COND_IND
                 , cast(nullif(PRIMARY_HIERARCHICAL_CONDITION, PRIMARY_HIERARCHICAL_CONDITION) as char(9)) as PRMRY_HIRCHCL_COND
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,cast(NULL as timestamp) as REC_UPDT_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
                 , { TAF_Closure.fix_old_dates('SRVC_ENDG_DT_DRVD') }
                 , { TAF_Closure.var_set_type2('SRVC_ENDG_DT_CD',0,cond1='1',cond2='2',cond3='3',cond4='4',cond5='5') }
                 , { TAF_Closure.var_set_taxo('BLG_PRVDR_NPPES_TXNMY_CD',cond1='8888888888', cond2='9999999999', cond3='000000000X', cond4='999999999X',

--- a/taf/RX/RXH.py
+++ b/taf/RX/RXH.py
@@ -103,7 +103,7 @@ class RXH:
                 , cll_cnt
                 , num_cll
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
-                ,cast(NULL as timestamp) as REC_UPDT_TS
+                ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
             from (
                 select
                     *,


### PR DESCRIPTION
## What is this and why are we doing it?
Recently we conducted a test with the CCW to confirm TAF flat files generated from DataConnect were syntactically correct and identical to a recent production run. Their results identified a discrepancy in our claim header data (IPH, OTH, LTH, and RXH) with `REC_UPDT_TS` values. We reached out to the production team to clarify and confirm our understanding of this data element. Then followed up with the CCW team to understand impacts to their pipeline. They expressed concern over this difference, so this change addresses that in our claim header data. During this time, I also noted a formatting difference to be addressed in a subsequent change.

SAS Code for Reference:
```
CONVERT_TIMEZONE('EDT', GETDATE()) AS REC_ADD_TS
CONVERT_TIMEZONE('EDT', GETDATE()) AS REC_UPDT_TS 
```

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4820


## What are the security implications from this change?
This change should not introduce any new security implications, as we are assigning a value using existing ETL.

## How did I test this?
I utilized my local development environment to simulate a job run for impacted file types. From there, I generated all of the SQL to be executed before and after my change to confirm the assignment of `REC_UPDT_TS` was the only difference.

Partial results for Reference:
```
(.venv) scleeton@BLD:/mnt/e/Projects/T-MSIS-Analytic-File-Generation-Python/test/integration_testing$ diff IP/IP_before.sql IP/IP_after.sql 
2297c2297
<                 , cast(NULL as timestamp) as REC_UPDT_TS
---
>                 , from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
(.venv) scleeton@BLD:/mnt/e/Projects/T-MSIS-Analytic-File-Generation-Python/test/integration_testing$ diff OT/OT_before.sql OT/OT_after.sql 
1832c1832
<                 ,cast(NULL as timestamp) as REC_UPDT_TS
---
>                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
(.venv) scleeton@BLD:/mnt/e/Projects/T-MSIS-Analytic-File-Generation-Python/test/integration_testing$ diff LT/LT_before.sql LT/LT_after.sql 
1873c1873
<                 ,cast(NULL as timestamp) as REC_UPDT_TS
---
>                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
(.venv) scleeton@BLD:/mnt/e/Projects/T-MSIS-Analytic-File-Generation-Python/test/integration_testing$ diff RX/RX_before.sql RX/RX_after.sql 
1195c1195
<                 ,cast(NULL as timestamp) as REC_UPDT_TS
---
>                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline
```

## Should there be new or updated documentation for this change? (Be specific.)
Ideally this should be documented in the TAF flat file specification (not sure this even exists). For the time being, I have left a comment next to the `REC_UPDT_TS` value to state this new requirement.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
