### PR TITLE
DBDAART-4917 Add Codeowner File

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @C1KB-tensileai @FICU-tensileai @AKDO-slalom @THOA-slalom @GPEC-adhoc @TUAS-forpeople @BKY3-forpeople @VPAI-bixal @MIPI-forpeople @GHHZ-bixal @RIE9-adhoc @a-pfeiffer @alihashmi-wh
+* @C1KB-tensileai @FICU-tensileai @AKDO-slalom @THOA-slalom @GPEC-adhoc @TUAS-forpeople @BKY3-forpeople @VPAI-bixal @MIPI-forpeople @GHHZ-bixal @RIE9-adhoc @a-pfeiffer @alihashmi-wh @XiaoBarry


### PR DESCRIPTION
## What is this and why are we doing it?
I have obtained the Github jobcode and have been added to the Mathematica TAF developers group. I updated the CODEOWNERS file to be added as an official code owner.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-4917

## What are the security implications from this change?
NA

## How did I test this?
NA

## Should there be new or updated documentation for this change? (Be specific.)
NA

## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [ ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
