### PR TITLE
DBDAART-4966 Change table type to Delta

### DIFF
--- a/taf/DE/DE0002.py
+++ b/taf/DE/DE0002.py
@@ -61,7 +61,7 @@ class DE0002(DE):
 
         z = f"""create table if not exists {self.de.DA_SCHEMA}.numbers
                 (slot int, month string)
-                using parquet"""
+                using delta"""
         self.de.append(type(self).__name__, z)
 
         z = f"""insert into {self.de.DA_SCHEMA}.numbers

--- a/taf/DE/DE0006.py
+++ b/taf/DE/DE0006.py
@@ -82,7 +82,7 @@ class DE0006(DE):
 
         z = f"""create table if not exists {self.de.DA_SCHEMA}.numbers_two
                 (slot int, month string)
-                using parquet"""
+                using delta"""
         self.de.append(type(self).__name__, z)
 
         z = f"""


### PR DESCRIPTION
## What is this and why are we doing it?
This addresses a potential issue when the `NUMBERS` and `NUMBERS_TWO` tables are created from some of the annual file type ETL. Only the Delta table format is supported for managed tables.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-4966


## What are the security implications from this change?
This change should not introduce any new security implications since we are changing the table format only.


## How did I test this?
During December's run, I utilized [this](https://cms-dataconnect.cloud.databricks.com/?o=667862292061707#notebook/4328980751037945) notebook to create the `NUMBERS` and `NUMBERS_TWO` tables after the annual ETL dropped them. Since they existed at runtime, the SQL generated by the TAF Python library did not overwrite these definitions (so the Delta format was used in each run, not Parquet).

Successful job runs:

1. [Annual Demographic Eligibility, CY 2022](https://cms-dataconnect.cloud.databricks.com/?o=667862292061707#job/295464658675329/run/797771311224567)
2. [Annual Demographic Eligibility, CY 2023](https://cms-dataconnect.cloud.databricks.com/?o=667862292061707#job/295464658675329/run/836733528820432)


## Should there be new or updated documentation for this change? (Be specific.)
I don't believe there's a need to create new or updated documentation for this change.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
