### PR TITLE
DBDAART-7483 - Added set_as_null function to TAF_Closure.py

### DIFF
--- a/taf/TAF_Closure.py
+++ b/taf/TAF_Closure.py
@@ -40,7 +40,7 @@ class TAF_Closure:
         return f"cast({alias}.{colname} as decimal(13, 2)) as {colname}"
 
     def set_as_null(colname: str, alias: str):
-        #This function accpets alias parameter but does not use it.  All functions called by cleanser need 2 parameters.    
+        #This function requires alias parameter but does not use it.  All functions called by cleanser need 2 parameters.    
         return f"NULL as {colname}"
 
     def var_set_type1(var: str, upper: bool = False, lpad: int = 0, new: str = "NO"):

--- a/taf/TAF_Closure.py
+++ b/taf/TAF_Closure.py
@@ -40,7 +40,7 @@ class TAF_Closure:
         return f"cast({alias}.{colname} as decimal(13, 2)) as {colname}"
 
     def set_as_null(colname: str, alias: str):
-
+        #This function accpets alias parameter but does not use it.  All functions called by cleanser need 2 parameters.    
         return f"NULL as {colname}"
 
     def var_set_type1(var: str, upper: bool = False, lpad: int = 0, new: str = "NO"):

--- a/taf/TAF_Closure.py
+++ b/taf/TAF_Closure.py
@@ -39,6 +39,10 @@ class TAF_Closure:
 
         return f"cast({alias}.{colname} as decimal(13, 2)) as {colname}"
 
+    def set_as_null(colname: str, alias: str):
+
+        return f"NULL as {colname}"
+
     def var_set_type1(var: str, upper: bool = False, lpad: int = 0, new: str = "NO"):
         """
         Helper function that acts as a template to standardize how name strings are manipulated.


### PR DESCRIPTION
## What is this and why are we doing it?
This change is to create a global function to set a field to null.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7438

## What are the security implications from this change?
N/A


## How did I test this?
before/after sqls with test usage attached to the ticket.

## Should there be new or updated documentation for this change? (Be specific.)
No

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ n/a] I have made corresponding changes to the documentation
