### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @C1KB-tensileai @FICU-tensileai @AKDO-slalom @THOA-slalom @GPEC-adhoc @TUAS-forpeople @BKY3-forpeople @VPAI-bixal @MIPI-forpeople @GHHZ-bixal @RIE9-adhoc @a-pfeiffer @alihashmi-wh @XiaoBarry
+* @C1KB-tensileai @FICU-tensileai @AKDO-slalom @THOA-slalom @GPEC-adhoc @TUAS-forpeople @BKY3-forpeople @VPAI-bixal @MIPI-forpeople @GHHZ-bixal @RIE9-adhoc @a-pfeiffer @alihashmi-wh @XiaoBarry @fumanjie @hls0231


### PR DESCRIPTION
Adding Manjie Fu (@fumanjie) and Heidi Bryan (@hls0231) from the IBM team as code owners.

## What is this and why are we doing it?
Need to add members of the IBM team to the list of code owners
Manjie Fu (@fumanjie) and Heidi Bryan (@hls0231)

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
not applicable

## What are the security implications from this change?
none

## How did I test this?
not applicable

## Should there be new or updated documentation for this change? (Be specific.)
no

## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [ ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
