### PR TITLE
Dbdaart 7257   rx  deprecate copay waived ind data element

### DIFF
--- a/taf/RX/RXH.py
+++ b/taf/RX/RXH.py
@@ -99,7 +99,7 @@ class RXH:
                 , { TAF_Closure.var_set_type6('TOT_BENE_COINSRNC_PD_AMT',new='BENE_COINSRNC_AMT', cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_COPMT_PD_AMT',new='BENE_COPMT_AMT',	cond1='88888888888.00', cond2='888888888.88', cond3='888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_DDCTBL_PD_AMT',new='BENE_DDCTBL_AMT', cond1='88888888888.00', cond2='888888888.88', cond3='888888888.00') }
-                , { TAF_Closure.var_set_type2('COPAY_WVD_IND', 0, cond1='0', cond2='1') }
+                , COPAY_WVD_IND
                 , cll_cnt
                 , num_cll
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS

--- a/taf/RX/RX_Metadata.py
+++ b/taf/RX/RX_Metadata.py
@@ -262,7 +262,6 @@ class RX_Metadata:
         "CLM_STUS_CD",
         "CLM_TYPE_CD",
         "CMS_64_FED_REIMBRSMT_CTGRY_CD",
-        "COPAY_WVD_IND",
         "DGNS_1_CD_IND",
         "DGNS_10_CD_IND",
         "DGNS_11_CD_IND",

--- a/taf/RX/RX_Metadata.py
+++ b/taf/RX/RX_Metadata.py
@@ -85,7 +85,8 @@ class RX_Metadata:
         "NCVRD_CHRGS_AMT": TAF_Closure.cast_as_dollar,
         "PLAN_ID_NUM": plan_id_num,
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
-        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD
+        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
+        "COPAY_WVD_IND":TAF_Closure.set_as_null
     }
 
     validator = {}


### PR DESCRIPTION
## What is this and why are we doing it?
CCB ticket calls for this field to be deprecated/set to null.  Leveraged TAF_Closure.set_as_null to set COPAY WAIVED IND to null upon extraction from T-MSIS, and var_set_type data cleaning function for this field in creation of view RXH.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7257

## What are the security implications from this change?
N/A

## How did I test this?
Visually examined the sql.   Ran TAF for test month/state before and after change, and compared all values before and after change.   All differences found in testing were expected.

## Should there be new or updated documentation for this change? (Be specific.)
Documentation team has already done their work.

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [x ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
