### PR TITLE
DBDAART-7280 - Leveraged TAF_Closure.Set_as_null to nullify copay_wvd…

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -202,7 +202,7 @@ class IPH:
                 , { TAF_Closure.var_set_type6('TOT_BENE_COINSRNC_PD_AMT',new='BENE_COINSRNC_AMT',cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_COPMT_PD_AMT',new='BENE_COPMT_AMT', cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_DDCTBL_PD_AMT',new='BENE_DDCTBL_AMT', cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
-                , { TAF_Closure.var_set_type2('COPAY_WVD_IND', 0, cond1='0', cond2='1') }
+                , COPAY_WVD_IND
                 , { TAF_Closure.fix_old_dates('OCRNC_01_CD_EFCTV_DT') }
                 , { TAF_Closure.fix_old_dates('OCRNC_01_CD_END_DT') }
                 , { TAF_Closure.var_set_type1('OCRNC_01_CD') }

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -422,7 +422,6 @@ class IP_Metadata:
         "CLM_STUS_CD",
         "CLM_TYPE_CD",
         "CMS_64_FED_REIMBRSMT_CTGRY_CD",
-        "COPAY_WVD_IND",
         "DGNS_1_CD_IND",
         "DGNS_10_CD_IND",
         "DGNS_11_CD_IND",

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -99,7 +99,8 @@ class IP_Metadata:
         "PLAN_ID_NUM": plan_id_num,
         "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
-        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD
+        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
+        "COPAY_WVD_IND":TAF_Closure.set_as_null
     }
 
     validator = {}


### PR DESCRIPTION
## What is this and why are we doing it?
CCB ticket calls for this field to be deprecated/set to null. Leveraged TAF_Closure.set_as_null to set COPAY WAIVED IND to null upon extraction from T-MSIS, and var_set_type data cleaning function for this field in creation of view RXH.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
*https://jiraent.cms.gov/browse/DBDAART-7280


## What are the security implications from this change?
N/A

## How did I test this?
Visually examined the sql. Ran TAF for test month/state before and after change, and compared all values before and after change. All differences found in testing were expected.

https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/3300450104828119/command/3300450104828142


## Should there be new or updated documentation for this change? (Be specific.)
Doc team has done this work.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
