### PR TITLE
DBDAART-10305 - For June TAF Run, update subData to remove 'CSO' file…

### DIFF
--- a/taf/TAF_Metadata.py
+++ b/taf/TAF_Metadata.py
@@ -985,8 +985,6 @@ class TAF_Metadata:
         spark = SparkSession.getActiveSession()
 
         subData = [
-            ("35", "ELG", "CSO", "2018-04-01", "9999-12-01"),
-            ("35", "TPL", "CSO", "2018-04-01", "9999-12-01"),
             ("48", "ELG", "CSO", "2023-04-05", "9999-12-01"),
             ("31", "ELG", "CSO", "2024-02-02", "9999-12-01"),
         ]


### PR DESCRIPTION
… submission types for New Mexico (state 35), because all four file types are 'TFFR' in June.

## What is this and why are we doing it?
For New Mexico (state 35), all four file submission types are 'TFFR' in June. This change is to delete the lines of New Mexico from subData where its ELG and TPL were previously assigned as 'CSO'.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-10305

## What are the security implications from this change?
None.

## How did I test this?
I created a notebook in VAL with the new version of the function, ran the function, viewed the output table, and confirmed it is as expected. The link to the notebook - https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/3300450104828381/command/3300450104828382

## Should there be new or updated documentation for this change? (Be specific.)
None.

## PR Checklist
- [ x ] The JIRA ticket number and a short description is in the subject line
- [ x ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [  ] I have made corresponding changes to the documentation
