### PR TITLE
DBDAART-7247 LT_Metadata.py;  Added COPAY_WVD_IND to cleanser list, l…

### DIFF
--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -136,7 +136,7 @@ class LTH:
                 , { TAF_Closure.var_set_type6('TOT_BENE_COINSRNC_PD_AMT',new='BENE_COINSRNC_AMT', cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_COPMT_PD_AMT', new='BENE_COPMT_AMT', cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_DDCTBL_PD_AMT', new='BENE_DDCTBL_AMT', cond1='888888888.88', cond2='888888888.00', cond3='88888888888.00') }
-                , { TAF_Closure.var_set_type2(var='COPAY_WVD_IND', lpad=0, cond1='0', cond2='1') }
+                ,COPAY_WVD_IND
                 , { TAF_Closure.fix_old_dates('OCRNC_01_CD_EFCTV_DT') }
                 , { TAF_Closure.fix_old_dates('OCRNC_01_CD_END_DT') }
                 , { TAF_Closure.var_set_type1(var='OCRNC_01_CD') }

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -80,7 +80,8 @@ class LT_Metadata:
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
         "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
         "ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
-        "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND
+        "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
+        "COPAY_WVD_IND":TAF_Closure.set_as_null,
 
     }
 
@@ -422,7 +423,7 @@ class LT_Metadata:
         "CLM_STUS_CD",
         "CLM_STUS_CTGRY_CD",
         "CLM_TYPE_CD",
-        "COPAY_WVD_IND",
+
         "DGNS_1_CD_IND",
         "DGNS_2_CD_IND",
         "DGNS_3_CD_IND",


### PR DESCRIPTION
…everaging TAF_Closure.set_as_null;  LT_Metadata.py:  Removed COPAY_WVD_IND  from the upper list;  LTH.py:  Removed var_set_type data cleaning function from COPAY_WVD_IND.

## What is this and why are we doing it?
CCB ticket to deprecate this field by setting it to null.   

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7247

## What are the security implications from this change?
N/A

## How did I test this?
Before/After Sql visual inspection;  Notebook in ticket that runs before and after TAF LT for one month for one state, tests COPAY_WVD_IND, and regression tests all other LT fields.  

## Should there be new or updated documentation for this change? (Be specific.)
Handled by documentation team.  

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
