### PR TITLE
DBDAART-7284 - OT_Metadata.py:  Added copay_wvd_ind to cleanser list,…

### DIFF
--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -127,7 +127,7 @@ class OTH:
                 , { TAF_Closure.fix_old_dates('BENE_COPMT_PD_DT') }
                 , { TAF_Closure.var_set_type6('TOT_BENE_DDCTBL_PD_AMT', new='BENE_DDCTBL_AMT', cond1='888888888.88', cond2='888888888', cond3='88888888888.00') }
                 , { TAF_Closure.fix_old_dates('BENE_DDCTBL_PD_DT') }
-                , { TAF_Closure.var_set_type2('COPAY_WVD_IND', 0, cond1='0', cond2='1') }
+                ,COPAY_WVD_IND
                 , { TAF_Closure.fix_old_dates('CPTATD_AMT_RQSTD_DT') }
                 , { TAF_Closure.var_set_type6('CPTATD_PYMT_RQSTD_AMT', 	cond1='888888888.88', cond2='888888888') }
                 , { TAF_Closure.var_set_type1('OCRNC_01_CD') }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -124,7 +124,8 @@ class OT_Metadata:
         "NCVRD_CHRGS_AMT": TAF_Closure.cast_as_dollar,
         "SRVC_ENDG_DT": dates_of_service,
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
-        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD
+        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
+        "COPAY_WVD_IND":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -382,7 +383,6 @@ class OT_Metadata:
         "CLM_STUS_CTGRY_CD",
         "CLM_TYPE_CD",
         "CMS_64_FED_REIMBRSMT_CTGRY_CD",
-        "COPAY_WVD_IND",
         "DGNS_1_CD_IND",
         "DGNS_2_CD_IND",
         "DGNS_3_CD_IND",


### PR DESCRIPTION
… leveraging TAF_Closure.set_as_null;   Removed COPAY_WVD_IND from upper list;   OTH.py:  removed var_set_type data cleaning functions from COPAY_WVD_IND field.

## What is this and why are we doing it?
Deprecating COPAY_WVD_IND field in OTH per CCB.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7284

## What are the security implications from this change?
N/A

## How did I test this?
Visual examination of sql plan;   Integration and regression testing in notebook identified in the Jira ticket. 

## Should there be new or updated documentation for this change? (Be specific.)
Documentation team conducting their changes. 

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
