### PR TITLE
DBDAART-7249  - Edited LT_Metadata.py to set RFRG_PRVDR_TYPE_CD to nu…

### DIFF
--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -115,7 +115,7 @@ class LTH:
                 , { TAF_Closure.var_set_spclty(var='BLG_PRVDR_SPCLTY_CD') }
                 , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NPI_NUM') }
-                , { TAF_Closure.var_set_prtype(var='RFRG_PRVDR_TYPE_CD') }
+                ,RFRG_PRVDR_TYPE_CD
                 , { TAF_Closure.var_set_spclty(var='RFRG_PRVDR_SPCLTY_CD') }
                 , { TAF_Closure.var_set_type1(var='PRVDR_LCTN_ID') }
                 , { TAF_Closure.var_set_type6('DAILY_RATE', cond1='88888.80', cond2='88888.00', cond3='88888.88') }

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -82,7 +82,7 @@ class LT_Metadata:
         "ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "COPAY_WVD_IND":TAF_Closure.set_as_null,
-
+        "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -476,7 +476,6 @@ class LT_Metadata:
         "RFRG_PRVDR_NUM",
         "RFRG_PRVDR_SPCLTY_CD",
         "RFRG_PRVDR_TXNMY_CD",
-        "RFRG_PRVDR_TYPE_CD",
         "RMTNC_NUM",
         "SBMTR_ID",
         "SECT_1115A_DEMO_IND",


### PR DESCRIPTION
## What is this and why are we doing it?
Jira ticket to deprecate REFERRING-PROV_TYPE data element from LTH

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7249

## What are the security implications from this change?
N/A

## How did I test this?
See Jira ticket for testing details:

1. Visual Inspection of SQL plan before and after
2. Visual inspection of TAF code to determine no other data elements were dependent on this field.
3. Visual examination to ensure prior CCB1 updates were present in DEV branch.
4. Integration testing - uploaded whl files for before and after the change, and compared all results in LTH and LTL.   

## Should there be new or updated documentation for this change? (Be specific.)
Documentation team responsible for this.  

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
