### PR TITLE
DBDAART-7248 - LT: Deprecate REFERRING-PROV-SPECIALTY data elemen

### DIFF
--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -116,7 +116,7 @@ class LTH:
                 , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NPI_NUM') }
                 ,RFRG_PRVDR_TYPE_CD
-                , { TAF_Closure.var_set_spclty(var='RFRG_PRVDR_SPCLTY_CD') }
+                ,RFRG_PRVDR_SPCLTY_CD
                 , { TAF_Closure.var_set_type1(var='PRVDR_LCTN_ID') }
                 , { TAF_Closure.var_set_type6('DAILY_RATE', cond1='88888.80', cond2='88888.00', cond3='88888.88') }
                 , { TAF_Closure.var_set_type2(var='PYMT_LVL_IND', lpad=0, cond1='1', cond2='2', cond3='3') }

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -82,7 +82,8 @@ class LT_Metadata:
         "ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "COPAY_WVD_IND":TAF_Closure.set_as_null,
-        "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null
+        "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null,
+        "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -474,7 +475,6 @@ class LT_Metadata:
         "PYMT_LVL_IND",
         "RFRG_PRVDR_NPI_NUM",
         "RFRG_PRVDR_NUM",
-        "RFRG_PRVDR_SPCLTY_CD",
         "RFRG_PRVDR_TXNMY_CD",
         "RMTNC_NUM",
         "SBMTR_ID",


### PR DESCRIPTION
## What is this and why are we doing it?
Jira ticket to deprecate this field.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7248

## What are the security implications from this change?
N/A

## How did I test this?
1) Visual Inspection of SQL before/After
2) Integration testing before/after and vs. MAIN in this notebook:  
https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/375544286553971

For code merging, I visually confirmed all cumulative CCB1 changes were in DEV branch, and also had github verify.   More testing info in the ticket. 

## Should there be new or updated documentation for this change? (Be specific.)
Handled by documentation team.


## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
