### PR TITLE
DBDAART-7271-IPH-Deprecate Referring Provider Type Code

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -176,7 +176,7 @@ class IPH:
                 , { TAF_Closure.var_set_spclty('BLG_PRVDR_SPCLTY_CD') }
                 , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM') }
-                , { TAF_Closure.var_set_prtype('rfrg_prvdr_type_cd') }
+                ,rfrg_prvdr_type_cd
                 , { TAF_Closure.var_set_spclty('RFRG_PRVDR_SPCLTY_CD') }
 
                 , { TAF_Closure.var_set_type1('PRVDR_LCTN_ID') }

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -100,7 +100,8 @@ class IP_Metadata:
         "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
         "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
-        "COPAY_WVD_IND":TAF_Closure.set_as_null
+        "COPAY_WVD_IND":TAF_Closure.set_as_null,
+        "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -510,7 +511,6 @@ class IP_Metadata:
         "RFRG_PRVDR_NUM",
         "RFRG_PRVDR_SPCLTY_CD",
         "RFRG_PRVDR_TXNMY_CD",
-        "RFRG_PRVDR_TYPE_CD",
         "SECT_1115A_DEMO_IND",
         "SPLIT_CLM_IND",
         "SRVC_TRKNG_TYPE_CD",


### PR DESCRIPTION
## What is this and why are we doing it?
Deprecate field per jira ticket.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7271

## What are the security implications from this change?
N/A

## How did I test this?
Visual examination of sql plan;   Visual examination of prior CCB1 commits in code;   Integration testing comparing CCB1, DEV and MAIN branches in this notebook:
https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/850991985027102


## Should there be new or updated documentation for this change? (Be specific.)
Documentation team.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
