### PR TITLE
DBDAART-7296 - IPH - Deprecate RFRG_PRVDR_SPCLTY_CD

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -177,7 +177,7 @@ class IPH:
                 , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM') }
                 ,rfrg_prvdr_type_cd
-                , { TAF_Closure.var_set_spclty('RFRG_PRVDR_SPCLTY_CD') }
+                ,RFRG_PRVDR_SPCLTY_CD
 
                 , { TAF_Closure.var_set_type1('PRVDR_LCTN_ID') }
                 , { TAF_Closure.var_set_type2('PYMT_LVL_IND', 0, cond1='1', cond2='2', cond3='3') }

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -101,7 +101,8 @@ class IP_Metadata:
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
         "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
         "COPAY_WVD_IND":TAF_Closure.set_as_null,
-        "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null
+        "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null,
+        "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -509,7 +510,6 @@ class IP_Metadata:
         "REV_CD",
         "RFRG_PRVDR_NPI_NUM",
         "RFRG_PRVDR_NUM",
-        "RFRG_PRVDR_SPCLTY_CD",
         "RFRG_PRVDR_TXNMY_CD",
         "SECT_1115A_DEMO_IND",
         "SPLIT_CLM_IND",


### PR DESCRIPTION
## What is this and why are we doing it?
Jira ticket to deprecate this field from CCB1 meeting.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7296

## What are the security implications from this change?
N/A

## How did I test this?
1) Visual Inspection of SQL plan before/after
2) Integration testing and comparison vs 2 other control runs.
3) Regression testing untouched fields.

For code merging:
1) Visually inspected code for prior CCB1 changes.
2) Leveraged github to compare to verify that DEV branch contains all CCB1 commits.

Please see jira ticket for more information on testing.

## Should there be new or updated documentation for this change? (Be specific.)
Documentation team doing this. 

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [x ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
