### PR TITLE
DBDAART-7265-IPL-Deprecate SRVCNG_PRVDR_TXNMY_CD

### DIFF
--- a/taf/IP/IPL.py
+++ b/taf/IP/IPL.py
@@ -62,7 +62,7 @@ class IPL:
                 , { TAF_Closure.var_set_type6('REV_CHRG_AMT', cond1=88888888888.88, cond2=99999999.9, cond3=888888888.88, cond4=8888888888.88, cond5=88888888.88, cond6=9999999999.99) }
                 , { TAF_Closure.var_set_type1('SRVCNG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1('PRSCRBNG_PRVDR_NPI_NUM', new='SRVCNG_PRVDR_NPI_NUM') }
-                , { TAF_Closure.var_set_taxo('SRVCNG_PRVDR_TXNMY_CD', cond1=8888888888, cond2=9999999999, cond3='000000000X', cond4='999999999X', cond5='NONE', cond6='XXXXXXXXXX', cond7='NO TAXONOMY') }
+                ,SRVCNG_PRVDR_TXNMY_CD
                 , { TAF_Closure.var_set_prtype('SRVCNG_PRVDR_TYPE_CD') }
                 , { TAF_Closure.var_set_spclty('SRVCNG_PRVDR_SPCLTY_CD') }
                 , { TAF_Closure.var_set_type1('OPRTG_PRVDR_NPI_NUM') }

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -102,7 +102,8 @@ class IP_Metadata:
         "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
         "COPAY_WVD_IND":TAF_Closure.set_as_null,
         "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null,
-        "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null
+        "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null,
+        "SRVCNG_PRVDR_TXNMY_CD":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -516,7 +517,6 @@ class IP_Metadata:
         "SRVC_TRKNG_TYPE_CD",
         "SRVCNG_PRVDR_NUM",
         "SRVCNG_PRVDR_SPCLTY_CD",
-        "SRVCNG_PRVDR_TXNMY_CD",
         "SRVCNG_PRVDR_TYPE_CD",
         "STC_CD tos_cd",
         "TMSIS_FIL_NAME",


### PR DESCRIPTION
## What is this and why are we doing it?
Deprecation of field from CCB1.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7265

## What are the security implications from this change?
N/A

## How did I test this?
See ticket for testing information. 

Visual Inspection of SQL plan before/after.
Visual inspection of code & Github compare for cumulative CCB1 changes
Integration and regression testing creating 1 month/1 state of TAF and comparing between MAIN, CCB1 and DEV branches.   All differences in results are expected. 

## Should there be new or updated documentation for this change? (Be specific.)
By documentation team

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
