### PR TITLE
DBDAART-7255-OTH-Deprecate-PRVDR_UNDER_DRCTN_NPI_NUM

### DIFF
--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -99,7 +99,7 @@ class OTH:
                 ,RFRG_PRVDR_TXNMY_CD
                 ,RFRG_PRVDR_TYPE_CD
                 ,RFRG_PRVDR_SPCLTY_CD
-                , { TAF_Closure.var_set_type1('PRVDR_UNDER_DRCTN_NPI_NUM', upper=True) }
+                ,PRVDR_UNDER_DRCTN_NPI_NUM
                 ,PRVDR_UNDER_DRCTN_TXNMY_CD
                 , { TAF_Closure.var_set_type1('PRVDR_UNDER_SPRVSN_NPI_NUM', upper=True) }
                 ,PRVDR_UNDER_SPRVSN_TXNMY_CD

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -130,7 +130,8 @@ class OT_Metadata:
         "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null,
         "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null,
         "PRVDR_UNDER_SPRVSN_TXNMY_CD":TAF_Closure.set_as_null,
-        "PRVDR_UNDER_DRCTN_TXNMY_CD":TAF_Closure.set_as_null
+        "PRVDR_UNDER_DRCTN_TXNMY_CD":TAF_Closure.set_as_null,
+        "PRVDR_UNDER_DRCTN_NPI_NUM":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -445,7 +446,6 @@ class OT_Metadata:
         "PRCDR_CD_IND",
         "PRVDR_FAC_TYPE_CD",
         "PRVDR_LCTN_ID",
-        "PRVDR_UNDER_DRCTN_NPI_NUM",
         "PRVDR_UNDER_SPRVSN_NPI_NUM",
         "PTNT_CNTL_NUM",
         "PTNT_STUS_CD",


### PR DESCRIPTION
## What is this and why are we doing it?
CCB1 ticket to deprecate this field.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7255

## What are the security implications from this change?
N/A

## How did I test this?
1) Visual inspection of SQL before/after change
2) Visual inspection of TAF code to determine field not used in subsequent calculations 
3) Code merge testing - visual inspection of dev branch to verify the cumulative ccb1 changes present;   Also used github interface.
4) Integration and regression testing in the notebook linked in the ticket.

## Should there be new or updated documentation for this change? (Be specific.)
Done by the documentation team. 

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
