### PR TITLE
DBDAART-7298-OTH-Deprecate-CPTATD_AMT_RQSTD_DT

### DIFF
--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -128,7 +128,7 @@ class OTH:
                 , { TAF_Closure.var_set_type6('TOT_BENE_DDCTBL_PD_AMT', new='BENE_DDCTBL_AMT', cond1='888888888.88', cond2='888888888', cond3='88888888888.00') }
                 , { TAF_Closure.fix_old_dates('BENE_DDCTBL_PD_DT') }
                 ,COPAY_WVD_IND
-                , { TAF_Closure.fix_old_dates('CPTATD_AMT_RQSTD_DT') }
+                ,CPTATD_AMT_RQSTD_DT
                 , { TAF_Closure.var_set_type6('CPTATD_PYMT_RQSTD_AMT', 	cond1='888888888.88', cond2='888888888') }
                 , { TAF_Closure.var_set_type1('OCRNC_01_CD') }
                 , { TAF_Closure.var_set_type1('OCRNC_02_CD') }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -131,7 +131,8 @@ class OT_Metadata:
         "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null,
         "PRVDR_UNDER_SPRVSN_TXNMY_CD":TAF_Closure.set_as_null,
         "PRVDR_UNDER_DRCTN_TXNMY_CD":TAF_Closure.set_as_null,
-        "PRVDR_UNDER_DRCTN_NPI_NUM":TAF_Closure.set_as_null
+        "PRVDR_UNDER_DRCTN_NPI_NUM":TAF_Closure.set_as_null,
+        "CPTATD_AMT_RQSTD_DT":TAF_Closure.set_as_null
     }
 
     validator = {}


### PR DESCRIPTION
## What is this and why are we doing it?
CCB1 ticket to deprecate this field

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7298

## What are the security implications from this change?
N/A

## How did I test this?
1) Visual inspection of SQL before/after change
2) Visual inspection of TAF code to determine field not used in subsequent calculations 
3) Code merge testing - visual inspection of dev branch to verify the cumulative ccb1 changes present;   Also used github interface;  Also compared DEV whl results to MAIN whl results to check for cumulative differences.
4) Integration and regression testing in the notebook linked in the ticket.

## Should there be new or updated documentation for this change? (Be specific.)
Done by documentation team.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
