### PR TITLE
DBDAART-7297-OTL-Deprecate-HCPCS_RATE

### DIFF
--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -84,7 +84,7 @@ class OTL:
                 , { TAF_Closure.var_set_type1('PRCDR_2_MDFR_CD', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type1('PRCDR_3_MDFR_CD', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type1('PRCDR_4_MDFR_CD', upper=True, lpad=2) }
-                , { TAF_Closure.var_set_type3('HCPCS_RATE', cond1='0.0000000000', cond2='0.000000000000', spaces=False) }
+                ,HCPCS_RATE
                 , { TAF_Closure.var_set_type2('SELF_DRCTN_TYPE_CD', 3, cond1='000', cond2='001', cond3='002', cond4='003') }
                 , { TAF_Closure.var_set_type1('PRE_AUTHRZTN_NUM') }
                 , { TAF_Closure.var_set_type4('UOM_CD', 'YES', cond1='F2', cond2='ML', cond3='GR', cond4='UN', cond5='ME') }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -132,7 +132,8 @@ class OT_Metadata:
         "PRVDR_UNDER_SPRVSN_TXNMY_CD":TAF_Closure.set_as_null,
         "PRVDR_UNDER_DRCTN_TXNMY_CD":TAF_Closure.set_as_null,
         "PRVDR_UNDER_DRCTN_NPI_NUM":TAF_Closure.set_as_null,
-        "CPTATD_AMT_RQSTD_DT":TAF_Closure.set_as_null
+        "CPTATD_AMT_RQSTD_DT":TAF_Closure.set_as_null,
+        "HCPCS_RATE":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -410,7 +411,6 @@ class OT_Metadata:
         "FUNDNG_SRC_NON_FED_SHR_CD",
         "HCBS_SRVC_CD",
         "HCBS_TXNMY",
-        "HCPCS_RATE",
         "HH_ENT_NAME",
         "HH_PRVDR_IND",
         "HH_PRVDR_NPI_NUM",


### PR DESCRIPTION
## What is this and why are we doing it?
Ticket to deprecate this field from CCB1.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7297

## What are the security implications from this change?
N/A

## How did I test this?
1) Visual inspection of SQL before/after change
2) Visual inspection of TAF code to determine how field used in subsequent calculations
3) Code merge testing - visual inspection of dev branch to verify the cumulative ccb1 changes present;   Also used github interface;  Also compared DEV whl results to MAIN whl results to check for cumulative differences.
4) Integration and regression testing in the notebook linked in the ticket.
5) Examined differences in downstream calculations based on this field.

## Should there be new or updated documentation for this change? (Be specific.)
Done by documentation team.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
