### PR TITLE
DBDAART-7273-RX-IP-OT-Deprecate-TOT_COPAY_AMT

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -184,7 +184,7 @@ class IPH:
                 , { TAF_Closure.var_set_type6('TOT_BILL_AMT', cond1='888888888.88', cond2='99999999.90', cond3='9999999.99', cond4='999999.99', cond5='999999.00') }
                 , { TAF_Closure.var_set_type6('TOT_ALOWD_AMT', cond1='888888888.88', cond2='99999999.00') }
                 , { TAF_Closure.var_set_type6('TOT_MDCD_PD_AMT', cond1='888888888.88') }
-                , { TAF_Closure.var_set_type6('TOT_COPAY_AMT', cond1='9999999.99', cond2='888888888.88', cond3='88888888888.00') }
+                ,TOT_COPAY_AMT
                 , { TAF_Closure.var_set_type6('TOT_TPL_AMT', cond1='888888888.88', cond2='999999.99') }
                 , { TAF_Closure.var_set_type6('TOT_OTHR_INSRNC_AMT', cond1='888888888.88') }
                 , { TAF_Closure.var_set_type6('TP_COINSRNC_PD_AMT', cond1='888888888.88') }

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -103,7 +103,8 @@ class IP_Metadata:
         "COPAY_WVD_IND":TAF_Closure.set_as_null,
         "RFRG_PRVDR_TYPE_CD":TAF_Closure.set_as_null,
         "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null,
-        "SRVCNG_PRVDR_TXNMY_CD":TAF_Closure.set_as_null
+        "SRVCNG_PRVDR_TXNMY_CD":TAF_Closure.set_as_null,
+        "TOT_COPAY_AMT":TAF_Closure.set_as_null
     }
 
     validator = {}

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -112,7 +112,7 @@ class OTH:
                 , { TAF_Closure.var_set_type6('TOT_BILL_AMT', cond1='999999.00', cond2='888888888.88', cond3='9999999.99', cond4='99999999.90', cond5='999999.99', cond6='9999999999.99') }
                 , { TAF_Closure.var_set_type6('TOT_ALOWD_AMT', cond1='99999999', cond2='888888888.88') }
                 , { TAF_Closure.var_set_type6('TOT_MDCD_PD_AMT', cond1='888888888.88', cond2='88888888888.80') }
-                , { TAF_Closure.var_set_type6('TOT_COPAY_AMT', cond1='888888888.88', cond2='9999999.99', cond3='88888888888.00') }
+                ,TOT_COPAY_AMT
                 , { TAF_Closure.var_set_type6('TOT_MDCR_DDCTBL_AMT', cond1='888888888.88', cond2='99999', cond3='88888888888.00') }
                 , { TAF_Closure.var_set_type6('TOT_MDCR_COINSRNC_AMT', cond1='888888888.88') }
                 , { TAF_Closure.var_set_type6('TOT_TPL_AMT', cond1='888888888.88', cond2='999999.99') }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -134,7 +134,8 @@ class OT_Metadata:
         "PRVDR_UNDER_DRCTN_NPI_NUM":TAF_Closure.set_as_null,
         "CPTATD_AMT_RQSTD_DT":TAF_Closure.set_as_null,
         "HCPCS_RATE":TAF_Closure.set_as_null,
-        "CPTATD_PYMT_RQSTD_AMT":TAF_Closure.set_as_null
+        "CPTATD_PYMT_RQSTD_AMT":TAF_Closure.set_as_null,
+        "TOT_COPAY_AMT":TAF_Closure.set_as_null
     }
 
     validator = {}

--- a/taf/RX/RXH.py
+++ b/taf/RX/RXH.py
@@ -89,7 +89,7 @@ class RXH:
                 , { TAF_Closure.var_set_type6('tot_bill_amt', cond1='999999.99', cond2='69999999999.93', cond3='999999.00', cond4='888888888.88', cond5='9999999.99', cond6='99999999.90') }
                 , { TAF_Closure.var_set_type6('tot_alowd_amt', cond1='888888888.88', cond2='99999999.00') }
                 , { TAF_Closure.var_set_type6('tot_mdcd_pd_amt', cond1='999999.99', cond2='888888888.88') }
-                , { TAF_Closure.var_set_type6('tot_copay_amt', cond1='88888888888.00', cond2='888888888.88', cond3='9999999.99') }
+                ,tot_copay_amt
                 , { TAF_Closure.var_set_type6('tot_tpl_amt', cond1='999999.99', cond2='888888888.88') }
                 , { TAF_Closure.var_set_type6('tot_othr_insrnc_amt', cond1='888888888.88') }
                 , { TAF_Closure.var_set_type6('tot_mdcr_ddctbl_amt', cond1='99999', cond2='88888888888.00', cond3='888888888.88') }

--- a/taf/RX/RX_Metadata.py
+++ b/taf/RX/RX_Metadata.py
@@ -86,7 +86,8 @@ class RX_Metadata:
         "PLAN_ID_NUM": plan_id_num,
         "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
         "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
-        "COPAY_WVD_IND":TAF_Closure.set_as_null
+        "COPAY_WVD_IND":TAF_Closure.set_as_null,
+        "TOT_COPAY_AMT":TAF_Closure.set_as_null
     }
 
     validator = {}


### PR DESCRIPTION
## What is this and why are we doing it?
CCB1 ticket to deprecate this field in 3 files. 

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-7273

## What are the security implications from this change?
N/A

## How did I test this?
1) Visual inspection of SQL before/after change
2) Visual inspection of TAF code to determine field not used in subsequent calculations 
3) Code merge testing - visual inspection of dev branch to verify the cumulative ccb1 changes present;   Also used github interface.  Also tested DEV whl vs. MAIN whl and differences as expected. 
4) Integration and regression testing in 3 notebooks in the ticket.

RX:  https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/830475602231167
 IP:  https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/830475602231214
OT:  https://cms-dataconnect-val.cloud.databricks.com/?o=955724715920583#notebook/830475602231258


## Should there be new or updated documentation for this change? (Be specific.)
Done by documentation team.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
