### PR TITLE
Include dummy PRV_LOC records in efts_fil_meta.

### DIFF
--- a/taf/PRV/PRV10.py
+++ b/taf/PRV/PRV10.py
@@ -284,6 +284,22 @@ class PRV10(PRV):
         """
         self.prv.append(type(self).__name__, z)
 
+    def loc_add_dummy(self):
+        """
+        Append dummy records (loc__g2) onto final PRV_LOC table
+        (Prov03_Location_CNST) to create a new view: 
+        Prov03_Location_CNST, which is referenced during creation 
+        of metadata to include dummy records when computing 
+        record counts by state.
+        """
+
+        z = f"""
+            create or replace temporary view Prov03_Location_CNST1 as
+            select * from Prov03_Location_CNST
+            union all
+            select * from loc__g2
+        """
+        self.prv.append(type(self).__name__, z)
 
 # -----------------------------------------------------------------------------
 # CC0 1.0 Universal

--- a/taf/PRV/PRV_Runner.py
+++ b/taf/PRV/PRV_Runner.py
@@ -126,6 +126,22 @@ class PRV_Runner(TAF_Runner):
         PRV09(self).build(self)
         PRV10(self).build(self)
 
+        '''
+        In PRV03, records are written to TAF.TAF_PRV_LOC from Prov03_Location_CNST.
+        Dummy location records may be created in PRV04, PRV05, and PRV10 when processing
+        PRV_LIC, PRV_IDT, and PRV_BED, respectively.
+        At the end of PRV10, dummy records are gathered into a temporary table, loc__g2, 
+        where they also get exported to TAF.TAF_PRV_LOC.
+        However, during metadata computation, the audit of record counts by state for the
+        PRV_LOC segment occurs on the table Prov03_Location_CNST, which does not include 
+        dummy records.
+        The following function creates a new view - Prov03_Location_CNST1 - as a 
+		concatenation of Prov03_Location_CNST and loc__g2. When running metadata for 
+		record counts by state on the PRV_LOC segment, the query will now be run on 
+		Prov03_Location_CNST1 rather than Prov03_Location_CNST, so that the count includes 
+		dummy records.
+        '''
+        PRV10(self).loc_add_dummy()
 
 # -----------------------------------------------------------------------------
 # CC0 1.0 Universal

--- a/taf/TAF_Runner.py
+++ b/taf/TAF_Runner.py
@@ -660,7 +660,17 @@ class TAF_Runner():
         df = spark.sql(cnt_sql)
         self.logger.debug(cnt_sql)
 
-        dict_audt = df.toPandas().to_dict(orient="records")
+        """
+        pgm_audt_cnt_id = 776: count of records on the TAF_PRV_LOC segment
+        Originally queries the Prov03_Location_CNST view, which does not include 
+        dummy records from the PRV_LIC, PRV_IDT, or PRV_BED segments.
+        Correction: instead query Prov03_Location_CNST1, which includes said dummy
+        records. By making the update here, no changes are necessary to TAF_Metadata.py
+        nor to the metadata function calls within any TAF Runner workbooks.
+        """
+        df_pd = df.toPandas()
+        df_pd.loc[df_pd['pgm_audt_cnt_id'] == 776, 'obj_name'] = df_pd['obj_name'].astype(str)+'1'
+        dict_audt = df_pd.to_dict(orient="records")
 
         for i in dict_audt:
             rstr = hash(time.time())


### PR DESCRIPTION
Record counts by state for PRV_LOC were previously pulled from Prov03_Location_CNST, which does not
include dummy records created during the PRV_IDT,
PRV_LIC, and PRV_BED segments. Updated code
creates a new view with dummy records added, from
which record counts are computed.

## What is this and why are we doing it?


* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####


## What are the security implications from this change?


## How did I test this?


## Should there be new or updated documentation for this change? (Be specific.)


## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [ ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
