### PR TITLE
DBDAART-10035-fix-null-values-in-SRC_FIL_CREAT_DT-in-taf-ann-inp-src

### DIFF
--- a/taf/APL/APL_Runner.py
+++ b/taf/APL/APL_Runner.py
@@ -194,7 +194,7 @@ class APL_Runner(TAF_Runner):
                 '{file.lower()}' as src_fil_type,
                 {file}_fil_dt as src_fil_dt,
                 da_run_id as src_da_run_id,
-                date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt,
+                fil_cret_dt as src_fil_creat_dt,
                 from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                 null as REC_UPDT_TS
 

--- a/taf/APR/APR_Runner.py
+++ b/taf/APR/APR_Runner.py
@@ -204,7 +204,7 @@ class APR_Runner(TAF_Runner):
                 lower('{file}') as src_fil_type,
                 {file}_FIL_DT as src_fil_dt,
                 DA_RUN_ID as SRC_DA_RUN_ID,
-                date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt,
+                fil_cret_dt as src_fil_creat_dt,
                 from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS,
                 null as REC_UPDT_TS
 

--- a/taf/DE/DE_Runner.py
+++ b/taf/DE/DE_Runner.py
@@ -290,7 +290,7 @@ class DE_Runner(TAF_Runner):
                 ,lower('{file}') as src_fil_type
                 ,{file}_FIL_DT as src_fil_dt
                 ,DA_RUN_ID AS SRC_DA_RUN_ID
-                ,date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt
+                ,fil_cret_dt as src_fil_creat_dt
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,null as REC_UPDT_TS
             FROM max_run_id_{file}_{inyear}

--- a/taf/UP/UP_Runner.py
+++ b/taf/UP/UP_Runner.py
@@ -273,7 +273,7 @@ class UP_Runner(TAF_Runner):
                 ,lower('{file}') as src_fil_type
                 ,{file}_FIL_DT as src_fil_dt
                 ,DA_RUN_ID AS SRC_DA_RUN_ID
-                ,date_format(date(fil_cret_dt),'MM/dd/yyyy') as src_fil_creat_dt
+                ,fil_cret_dt as src_fil_creat_dt
                 ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
                 ,null as REC_UPDT_TS
             FROM max_run_id_{file}_{inyear}


### PR DESCRIPTION
## What is this and why are we doing it?
The annual runner code reads in column 'fil_cret_dt' from 'efts_fil_meta' table to create the new column 'src_fil_creat_dt'. The input column 'fil_cret_dt' is a string, not a date, which means the date() function is not applicable and why we are observing null values. Also, since 'fil_cret_dt' is already in 'mm/dd/yyyy' format, there is no need to apply date_format() function. Both of functions can be removed from the code. There is no need to change V5 DDL as it should be a string.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-10035


## What are the security implications from this change?
NA

## How did I test this?
https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/740819107307326?o=955724715920583#command/740819107307335

## Should there be new or updated documentation for this change? (Be specific.)
NA

## PR Checklist
- [x ] The JIRA ticket number and a short description is in the subject line
- [x ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
