### PR TITLE
DBDAART-10633-Add-additional-staff-to-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@a-pfeiffer @alihashmi-wh @XiaoBarry @fumanjie @hls0231
+@a-pfeiffer @alihashmi-wh @XiaoBarry @fumanjie @hls0231 @c-arsen @ncohen-mathematica


### PR DESCRIPTION
## What is this and why are we doing it?
Add Celia Arsen and Nikki Cohen from Mathematica to CODEOWNERS 

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-10633


## What are the security implications from this change?
NA

## How did I test this?
I confirmed that the CODEOWNERS file is valid after adding both of them.


## Should there be new or updated documentation for this change? (Be specific.)
NA

## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [ ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
