### PR TITLE
Dbdaart 12840 ot deprecate data elements

### DIFF
--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -69,8 +69,8 @@ class OTH:
                 , case when lpad(wvr_type_cd, 2, '0') = '88' then NULL else { TAF_Closure.var_set_type5('wvr_type_cd', lpad=2,lowerbound=1,upperbound=33,multiple_condition='YES') }
 
                 , { TAF_Closure.var_set_type1('WVR_ID') }
-                , { TAF_Closure.var_set_type2('srvc_trkng_type_cd', 2, cond1='00', cond2='01', cond3='02', cond4='03', cond5='04', cond6='05', cond7='06') }
-                , { TAF_Closure.var_set_type6('SRVC_TRKNG_PYMT_AMT', cond1='888888888.88') }
+                ,srvc_trkng_type_cd
+                ,SRVC_TRKNG_PYMT_AMT
                 , { TAF_Closure.var_set_type2('OTHR_INSRNC_IND', 0, cond1='0', cond2='1') }
                 , { TAF_Closure.var_set_type2('othr_tpl_clctn_cd', 3, cond1='000', cond2='001', cond3='002', cond4='003', cond5='004', cond6='005', cond7='006', cond8='007') }
                 , { TAF_Closure.var_set_type2('FIXD_PYMT_IND', 0, cond1='0', cond2='1') }
@@ -83,10 +83,10 @@ class OTH:
                 , { TAF_Closure.var_set_type2('HLTH_CARE_ACQRD_COND_CD', 0, cond1='0', cond2='1') }
                 , { TAF_Closure.var_set_fills('DGNS_1_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
                 , { TAF_Closure.var_set_type2('DGNS_1_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
-                , { TAF_Closure.var_set_poa('DGNS_POA_1_CD_IND') }
+                , DGNS_POA_1_CD_IND
                 , { TAF_Closure.var_set_fills('DGNS_2_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
                 , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
-                , { TAF_Closure.var_set_poa('DGNS_POA_2_CD_IND') }
+                , DGNS_POA_2_CD_IND
                 , { TAF_Closure.var_set_type1('SRVC_PLC_CD', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type1('PRVDR_LCTN_ID') }
                 , { TAF_Closure.var_set_type1('BLG_PRVDR_NUM') }
@@ -101,7 +101,7 @@ class OTH:
                 ,RFRG_PRVDR_SPCLTY_CD
                 ,PRVDR_UNDER_DRCTN_NPI_NUM
                 ,PRVDR_UNDER_DRCTN_TXNMY_CD
-                , { TAF_Closure.var_set_type1('PRVDR_UNDER_SPRVSN_NPI_NUM', upper=True) }
+                ,PRVDR_UNDER_SPRVSN_NPI_NUM
                 ,PRVDR_UNDER_SPRVSN_TXNMY_CD
                 , { TAF_Closure.var_set_type2('HH_PRVDR_IND', 0, cond1='0', cond2='1') }
                 , { TAF_Closure.var_set_type1('HH_PRVDR_NPI_NUM') }

--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -48,8 +48,7 @@ class OTL:
                 , { TAF_Closure.fix_old_dates('PRCDR_CD_DT') }
                 , { TAF_Closure.var_set_proc('PRCDR_CD_IND', upper=True) }
                 , { TAF_Closure.var_set_type1('PRCDR_1_MDFR_CD', upper=True, lpad=2) }
-                , case when lpad(IMNZTN_TYPE_CD, 2, '0') = '88' then NULL
-                    else { TAF_Closure.var_set_type5('IMNZTN_type_cd', lpad=2, lowerbound=0, upperbound=29, multiple_condition='YES') }
+                , IMNZTN_type_cd
                 , { TAF_Closure.var_set_type6('BILL_AMT', cond1='888888888.88', cond2='9999999999.99', cond3='999999.99', cond4='999999') }
                 , { TAF_Closure.var_set_type6('ALOWD_AMT', cond1='99999999.00', cond2='888888888.88', cond3='9999999999.99') }
                 , { TAF_Closure.var_set_type6('BENE_COPMT_PD_AMT', cond1='88888888888.00', cond2='888888888.88') }
@@ -61,7 +60,7 @@ class OTL:
                 , { TAF_Closure.var_set_type6('SVC_QTY_ACTL', new ='SRVC_QTY_ACTL', cond1='999999.000', cond2='888888.000', cond3='999999.99') }
                 , { TAF_Closure.var_set_type6('SVC_QTY_ALOWD', new ='SRVC_QTY_ALOWD', cond1='999999.000', cond2='888888.000', cond3='888888.880', cond4='99999.999', cond5='99999') }
                 , { TAF_Closure.var_set_tos('TOS_CD') }
-                , { TAF_Closure.var_set_type5('BNFT_TYPE_CD', lpad=3, lowerbound='001', upperbound='108') }
+                ,BNFT_TYPE_CD
                 , { TAF_Closure.var_set_type2('HCBS_SRVC_CD', 0, cond1=1, cond2=2, cond3=3, cond4=4, cond5=5, cond6=6, cond7=7, upper=True) }
                 , { TAF_Closure.var_set_type1('HCBS_TXNMY', upper=True, lpad=5) }
                 , { TAF_Closure.var_set_type1('SRVCNG_PRVDR_NUM') }
@@ -75,10 +74,8 @@ class OTL:
                     else { TAF_Closure.var_set_type5('TOOTH_ORAL_CVTY_AREA_DSGNTD_CD', lpad=2, lowerbound=0, upperbound=10, multiple_condition='YES', upper=True) }
                 , { TAF_Closure.var_set_type4('TOOTH_SRFC_CD', 'YES', cond1='B', cond2='D', cond3='F', cond4='I', cond5='L', cond6='M', cond7='O') }
                 , { TAF_Closure.var_set_type2('CMS_64_FED_REIMBRSMT_CTGRY_CD', 2, cond1='01', cond2='02', cond3='03', cond4='04') }
-                , case when XIX_SRVC_CTGRY_CD in { tuple(TAF_Metadata.XIX_SRVC_CTGRY_CD_values) } then XIX_SRVC_CTGRY_CD
-                else NULL end as XIX_SRVC_CTGRY_CD
-                , case when XXI_SRVC_CTGRY_CD in { tuple(TAF_Metadata.XXI_SRVC_CTGRY_CD_values) } then XXI_SRVC_CTGRY_CD
-                    else NULL end as XXI_SRVC_CTGRY_CD
+                ,XIX_SRVC_CTGRY_CD
+                ,XXI_SRVC_CTGRY_CD
                 , { TAF_Closure.var_set_type1('STATE_NOTN_TXT') }
                 , { TAF_Closure.var_set_fills('NDC_CD', cond1='0', cond2='8', cond3='9', cond4='#', spaces=True) }
                 , { TAF_Closure.var_set_type1('PRCDR_2_MDFR_CD', upper=True, lpad=2) }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -123,8 +123,6 @@ class OT_Metadata:
         "LINE_ADJSTMT_IND": TAF_Closure.cleanADJSTMT_IND,
         "NCVRD_CHRGS_AMT": TAF_Closure.cast_as_dollar,
         "SRVC_ENDG_DT": dates_of_service,
-        "XIX_SRVC_CTGRY_CD": TAF_Closure.cleanXIX_SRVC_CTGRY_CD,
-        "XXI_SRVC_CTGRY_CD": TAF_Closure.cleanXXI_SRVC_CTGRY_CD,
         "COPAY_WVD_IND":TAF_Closure.set_as_null,
         "RFRG_PRVDR_TXNMY_CD":TAF_Closure.set_as_null,
         "RFRG_PRVDR_SPCLTY_CD":TAF_Closure.set_as_null,
@@ -135,7 +133,16 @@ class OT_Metadata:
         "CPTATD_AMT_RQSTD_DT":TAF_Closure.set_as_null,
         "HCPCS_RATE":TAF_Closure.set_as_null,
         "CPTATD_PYMT_RQSTD_AMT":TAF_Closure.set_as_null,
-        "TOT_COPAY_AMT":TAF_Closure.set_as_null
+        "TOT_COPAY_AMT":TAF_Closure.set_as_null,
+        "BNFT_TYPE_CD":TAF_Closure.set_as_null,
+        "IMNZTN_TYPE_CD":TAF_Closure.set_as_null,
+        "SRVC_TRKNG_PYMT_AMT":TAF_Closure.set_as_null,
+        "PRVDR_UNDER_SPRVSN_NPI_NUM":TAF_Closure.set_as_null,
+        "XIX_SRVC_CTGRY_CD":TAF_Closure.set_as_null,
+        "XXI_SRVC_CTGRY_CD":TAF_Closure.set_as_null,
+        "DGNS_POA_1_CD_IND":TAF_Closure.set_as_null,
+        "DGNS_POA_2_CD_IND":TAF_Closure.set_as_null
+        
     }
 
     validator = {}
@@ -389,7 +396,6 @@ class OT_Metadata:
         "BLG_PRVDR_TXNMY_CD",
         "BLG_PRVDR_TYPE_CD",
         "BLG_UNIT_CD",
-        "BNFT_TYPE_CD",
         "BRDR_STATE_IND",
         "CHK_NUM",
         "CLL_STUS_CD",
@@ -426,7 +432,6 @@ class OT_Metadata:
         "HH_PRVDR_IND",
         "HH_PRVDR_NPI_NUM",
         "HLTH_CARE_ACQRD_COND_CD",
-        "IMNZTN_TYPE_CD",
         "MDCR_BENE_ID",
         "MDCR_CMBND_DDCTBL_IND",
         "MDCR_HICN_NUM",
@@ -458,7 +463,6 @@ class OT_Metadata:
         "PRCDR_CD_IND",
         "PRVDR_FAC_TYPE_CD",
         "PRVDR_LCTN_ID",
-        "PRVDR_UNDER_SPRVSN_NPI_NUM",
         "PTNT_CNTL_NUM",
         "PTNT_STUS_CD",
         "PYMT_LVL_IND",
@@ -472,7 +476,6 @@ class OT_Metadata:
         "SELF_DRCTN_TYPE_CD",
         "SPLIT_CLM_IND",
         "SRC_LCTN_CD",
-        "SRVC_TRKNG_TYPE_CD",
         "SRVCNG_PRVDR_NUM",
         "SRVCNG_PRVDR_SPCLTY_CD",
         "SRVCNG_PRVDR_TXNMY_CD",
@@ -486,8 +489,6 @@ class OT_Metadata:
         "WVR_ID",
         "WVR_TYPE_CD",
         "XOVR_IND",
-        "XIX_SRVC_CTGRY_CD",
-        "XXI_SRVC_CTGRY_CD",
         "ORDRG_PRVDR_NUM",
         "ORDRG_PRVDR_NPI_NUM",
         "IHS_SVC_IND"

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -141,7 +141,8 @@ class OT_Metadata:
         "XIX_SRVC_CTGRY_CD":TAF_Closure.set_as_null,
         "XXI_SRVC_CTGRY_CD":TAF_Closure.set_as_null,
         "DGNS_POA_1_CD_IND":TAF_Closure.set_as_null,
-        "DGNS_POA_2_CD_IND":TAF_Closure.set_as_null
+        "DGNS_POA_2_CD_IND":TAF_Closure.set_as_null,
+        "SRVC_TRKNG_TYPE_CD":TAF_Closure.set_as_null
         
     }
 


### PR DESCRIPTION
## What is this and why are we doing it?
CCB2 Ticket to deprecate multiple fields in OTH and OTL


* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-12840

## What are the security implications from this change?
N/A

## How did I test this?
Testing details in Jira ticket;
Visual Inspection of changes to SQL plan.
Code merge testing using Github UI.
Unit and regression testing in the following notebooks:
  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/1356854838819139?o=955724715920583
  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/2471317359912542?o=955724715920583

## Should there be new or updated documentation for this change? (Be specific.)
Done by documentation team. 

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
