### PR TITLE
DBDAART-12843; DBDAART-13992; DBDAART-13997

### DIFF
--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -183,8 +183,7 @@ class OTH:
                 ,TOT_BENE_COPMT_LBLE_AMT
                 ,TOT_BENE_COINSRNC_LBLE_AMT
                 ,CMBND_BENE_CST_SHRNG_PD_AMT
-                ,nullif(trim(ORDRG_PRVDR_NUM),'') as ORDRG_PRVDR_NUM
-                ,nullif(trim(ORDRG_PRVDR_NPI_NUM),'') as ORDRG_PRVDR_NPI_NUM
+
             from (
                 select
                     *,

--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -92,6 +92,8 @@ class OTL:
                 , PRCDR_CCS_CTGRY_CD
                 , SRVCNG_PRVDR_NPPES_TXNMY_CD
                 , { TAF_Closure.var_set_type1('IHS_SVC_IND',upper=True) }
+                ,nullif(trim(ORDRG_PRVDR_NUM),'') as ORDRG_PRVDR_NUM
+                ,nullif(trim(ORDRG_PRVDR_NPI_NUM),'') as ORDRG_PRVDR_NPI_NUM
             from (
                 select
                     *,

--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -73,7 +73,7 @@ class OTL:
                 , case when lpad(upper(TOOTH_ORAL_CVTY_AREA_DSGNTD_CD), 2, '0') in ('20', '30', '40') then lpad(upper(TOOTH_ORAL_CVTY_AREA_DSGNTD_CD), 2, '0')
                     else { TAF_Closure.var_set_type5('TOOTH_ORAL_CVTY_AREA_DSGNTD_CD', lpad=2, lowerbound=0, upperbound=10, multiple_condition='YES', upper=True) }
                 , { TAF_Closure.var_set_type4('TOOTH_SRFC_CD', 'YES', cond1='B', cond2='D', cond3='F', cond4='I', cond5='L', cond6='M', cond7='O') }
-                , { TAF_Closure.var_set_type2('CMS_64_FED_REIMBRSMT_CTGRY_CD', 2, cond1='01', cond2='02', cond3='03', cond4='04') }
+                , { TAF_Closure.var_set_type2('FED_REIMBRSMT_CTGRY_CD', 2, cond1='01', cond2='02', cond3='03', cond4='04') }
                 ,XIX_SRVC_CTGRY_CD
                 ,XXI_SRVC_CTGRY_CD
                 , { TAF_Closure.var_set_type1('STATE_NOTN_TXT') }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -142,8 +142,11 @@ class OT_Metadata:
         "XXI_SRVC_CTGRY_CD":TAF_Closure.set_as_null,
         "DGNS_POA_1_CD_IND":TAF_Closure.set_as_null,
         "DGNS_POA_2_CD_IND":TAF_Closure.set_as_null,
-        "SRVC_TRKNG_TYPE_CD":TAF_Closure.set_as_null
-        
+        "SRVC_TRKNG_TYPE_CD":TAF_Closure.set_as_null,
+        "DGNS_1_CD":TAF_Closure.set_as_null,
+        "DGNS_2_CD":TAF_Closure.set_as_null,
+        "DGNS_1_CD_IND":TAF_Closure.set_as_null,
+        "DGNS_2_CD_IND":TAF_Closure.set_as_null
     }
 
     validator = {}
@@ -301,7 +304,7 @@ class OT_Metadata:
             "BNFT_TYPE_CD",
             "BILL_AMT",
             "CLL_STUS_CD",
-            "CMS_64_FED_REIMBRSMT_CTGRY_CD",
+            "FED_REIMBRSMT_CTGRY_CD",
             "BENE_COPMT_PD_AMT",
             "SRVC_ENDG_DT",
             "HCPCS_SRVC_CD",
@@ -408,7 +411,7 @@ class OT_Metadata:
         "CLM_STUS_CD",
         "CLM_STUS_CTGRY_CD",
         "CLM_TYPE_CD",
-        "CMS_64_FED_REIMBRSMT_CTGRY_CD",
+        "FED_REIMBRSMT_CTGRY_CD",
         "DGNS_1_CD_IND",
         "DGNS_2_CD_IND",
         "DGNS_3_CD_IND",
@@ -703,7 +706,7 @@ class OT_Metadata:
         "TOOTH_NUM",
         "TOOTH_ORAL_CVTY_AREA_DSGNTD_CD",
         "TOOTH_SRFC_CD",
-        "CMS_64_FED_REIMBRSMT_CTGRY_CD",
+        "FED_REIMBRSMT_CTGRY_CD",
         "XIX_SRVC_CTGRY_CD",
         "XXI_SRVC_CTGRY_CD",
         "STATE_NOTN_TXT",

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -288,9 +288,7 @@ class OT_Metadata:
             "TOT_BENE_DDCTBL_LBLE_AMT",
             "TOT_BENE_COPMT_LBLE_AMT",
             "TOT_BENE_COINSRNC_LBLE_AMT",
-            "CMBND_BENE_CST_SHRNG_PD_AMT",
-            "ORDRG_PRVDR_NUM",
-            "ORDRG_PRVDR_NPI_NUM"
+            "CMBND_BENE_CST_SHRNG_PD_AMT"
             
         ],
         "COT00003": [
@@ -351,7 +349,9 @@ class OT_Metadata:
             "STC_CD",
             "XIX_SRVC_CTGRY_CD",
             "XXI_SRVC_CTGRY_CD",
-            "IHS_SVC_IND"
+            "IHS_SVC_IND",
+            "ORDRG_PRVDR_NUM",
+            "ORDRG_PRVDR_NPI_NUM"
         ],
     }
 
@@ -652,9 +652,8 @@ class OT_Metadata:
         "TOT_BENE_DDCTBL_LBLE_AMT",
         "TOT_BENE_COPMT_LBLE_AMT",
         "TOT_BENE_COINSRNC_LBLE_AMT",
-        "CMBND_BENE_CST_SHRNG_PD_AMT",
-        "ORDRG_PRVDR_NUM",
-        "ORDRG_PRVDR_NPI_NUM"
+        "CMBND_BENE_CST_SHRNG_PD_AMT"
+
     ]
 
     line_columns = [
@@ -722,7 +721,9 @@ class OT_Metadata:
         "LINE_NUM",
         "PRCDR_CCS_CTGRY_CD",
         "SRVCNG_PRVDR_NPPES_TXNMY_CD",
-        "IHS_SVC_IND"
+        "IHS_SVC_IND",
+        "ORDRG_PRVDR_NUM",
+        "ORDRG_PRVDR_NPI_NUM"
     ]
 
 


### PR DESCRIPTION
## What is this and why are we doing it?
Adapting multiple fields to the new T-MSIS V4 data for OT files. 

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####

https://jiraent.cms.gov/browse/DBDAART-12843
https://jiraent.cms.gov/browse/DBDAART-13992
https://jiraent.cms.gov/browse/DBDAART-13997


## What are the security implications from this change?


## How did I test this?
- Visual inspection of before/after changes to the SQL Plan.
- Code Merge testing via Github interface.
- Unit testing where possible:   DX fields are nulled, Renamed CMS-64 field has values carried through but we don't have other data for A/B testing;   TMISIS V4 data did not have any of the Ordering Provider fields populated so could not test that these fields were carried through.



## Should there be new or updated documentation for this change? (Be specific.)
Done by the documentation team.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
