### PR TITLE
DBDAART-14179- OT DX Remove Cast as Int, update DX_WIDE view name.

### DIFF
--- a/taf/OT/OT.py
+++ b/taf/OT/OT.py
@@ -154,7 +154,7 @@ class OT(TAF):
                 HEADER.ADJSTMT_CLM_NUM = RN.ADJSTMT_CLM_NUM_LINE and
                 HEADER.ADJDCTN_DT = RN.ADJDCTN_DT_LINE and
                 HEADER.ADJSTMT_IND = RN.LINE_ADJSTMT_IND
-            left join dx_wide as dx
+            left join dx_wide_{fl} as dx
             on (
                     HEADER.NEW_SUBMTG_STATE_CD = dx.NEW_SUBMTG_STATE_CD and
                     HEADER.ORGNL_CLM_NUM = dx.ORGNL_CLM_NUM and
@@ -225,7 +225,7 @@ class OT(TAF):
         
         #transpose the DX file to the appropriate number of DX fields.
         z = f"""
-            create or replace temporary view dx_wide as
+            create or replace temporary view dx_wide_{fl} as
             select 
                 new_submtg_state_cd
                 ,orgnl_clm_num

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -146,8 +146,7 @@ class OT_Metadata:
         "DGNS_POA_1_CD_IND":TAF_Closure.set_as_null,
         "DGNS_POA_2_CD_IND":TAF_Closure.set_as_null,
         "SRVC_TRKNG_TYPE_CD":TAF_Closure.set_as_null,
-        "DGNS_CD":TAF_Closure.compress_dots,
-        "DGNS_SQNC_NUM":TAF_Closure.cast_as_int
+        "DGNS_CD":TAF_Closure.compress_dots
     }
 
     validator = {}


### PR DESCRIPTION
## What is this and why are we doing it?
Ticket to check if data are integer now and remove cast if they are;  Also updated dx_wide view name to be file type specific. 

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-14179

## What are the security implications from this change?
N/A

## How did I test this?
1) Code merge testing - all CCB2 commits included in this branch.
2) Visual inspection of SQL Plan changes.
3)  No changes to the output data were anticipated due to this change, so this notebook regression tests every field in OT vs. prior run, and no unexpected differences were found. 

New test run:
https://cms-dataconnect-val.cloud.databricks.com/jobs/686328978521045/runs/272348429624802?o=955724715920583

Regression test notebook:
https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/3554598965490599?o=955724715920583#command/3554598965490602

## Should there be new or updated documentation for this change? (Be specific.)
Documentation in ticket. 

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
