### PR TITLE
Dbdaart 14458 ot dx nullness and admitting type

### DIFF
--- a/taf/OT/OT.py
+++ b/taf/OT/OT.py
@@ -2,6 +2,7 @@ from taf.OT.OT_Metadata import OT_Metadata
 from taf.OT.OT_Runner import OT_Runner
 from taf.TAF import TAF
 from taf.TAF_Closure import TAF_Closure
+from taf.TAF_Metadata import TAF_Metadata
 
 
 class OT(TAF):
@@ -203,7 +204,7 @@ class OT(TAF):
                             else 6 end as sort_val
                     ,case when DGNS_SQNC_NUM is null or
                         nullif(trim(dgns_type_cd),'') is null or
-                        trim(upper(dgns_type_cd)) not in ('A','D','E','O','P','R')
+                        trim(upper(dgns_type_cd)) not in {tuple(TAF_Metadata.DGNS_TYPE_CD_values)}
                         then 1 else 0 end as null_flag
                     ,case when trim(upper(dgns_type_cd)) = 'A' then 1 else 0 end as admitting_flag
                     from

--- a/taf/OT/OT.py
+++ b/taf/OT/OT.py
@@ -201,7 +201,10 @@ class OT(TAF):
                             when trim(upper(dgns_type_cd)) = "E" then 4
                             when trim(upper(dgns_type_cd)) = "R" then 5
                             else 6 end as sort_val
-                    ,case when DGNS_SQNC_NUM is null or nullif(trim(dgns_type_cd),'') is null then 1 else 0 end as null_flag
+                    ,case when DGNS_SQNC_NUM is null or
+                        nullif(trim(dgns_type_cd),'') is null or
+                        trim(upper(dgns_type_cd)) not in ('A','D','E','O','P','R')
+                        then 1 else 0 end as null_flag
                     ,case when trim(upper(dgns_type_cd)) = 'A' then 1 else 0 end as admitting_flag
                     from
                         {TMSIS_SCHEMA}.{_2x_segment} as a

--- a/taf/OT/OT_DX.py
+++ b/taf/OT/OT_DX.py
@@ -1,6 +1,7 @@
 from taf.OT.OT_Runner import OT_Runner
 from taf.OT.OT_Metadata import OT_Metadata
 from taf.TAF_Closure import TAF_Closure
+from taf.TAF_Metadata import TAF_Metadata
 
 
 class OT_DX:
@@ -37,7 +38,7 @@ class OT_DX:
                 when ADJDCTN_DT=to_date('1960-01-01') then NULL
                 else ADJDCTN_DT
                 end as ADJDCTN_DT
-            ,{ TAF_Closure.var_set_type4('DGNS_TYPE_CD', 'YES', cond1='A', cond2='D', cond3='E', cond4='O', cond5='P', cond6='R') }
+            , case when trim(upper(dgns_type_cd)) in {tuple(TAF_Metadata.DGNS_TYPE_CD_values)} then trim(upper(dgns_type_cd)) else NULL end as DGNS_TYPE_CD
             , DGNS_SQNC_NUM
             ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
             ,DGNS_CD

--- a/taf/OT/OT_Runner.py
+++ b/taf/OT/OT_Runner.py
@@ -40,6 +40,9 @@ class OT_Runner(TAF_Runner):
         from taf.OT.OTL import OTL
         from taf.OT.OT_DX import OT_DX
 
+        #TAF 9.0:  Number of DX codes to be backfilled to header file.
+        NUMDX = 2
+
         # -------------------------------------------------
         #   Produces:
         # -------------------------------------------------
@@ -77,7 +80,7 @@ class OT_Runner(TAF_Runner):
 
         ot = OT(self)
         ot.select_dx(
-            "tmsis", "COT00004", "tmsis_clm_dx_othr_toc", "OTHR_TOC","FA_HDR_OTHR_TOC",2
+            "tmsis", "COT00004", "tmsis_clm_dx_othr_toc", "OTHR_TOC","FA_HDR_OTHR_TOC",NUMDX
         )
 
         # -------------------------------------------------


### PR DESCRIPTION
## What is this and why are we doing it?
Adding exclusions from backfilling for nullness and admitting dx codes.
Also updated code to make references to global DGNS TYPE CODE valid values list stored in TAF_Metadata.py

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-14458
https://jiraent.cms.gov/browse/DBDAART-14341


## What are the security implications from this change?
N/A


## How did I test this?

1) Regression testing vs. CCB2 whl file - No unintended changes from this change found.

https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/3554598965490599?o=955724715920583

2) Scenario testing - No issues found:

https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/1536460811690419?o=955724715920583

3)   Summary Stats - No issues found:

https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/1437561348809002?o=955724715920583

## Should there be new or updated documentation for this change? (Be specific.)
Covered by the documentation team.   

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
