### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@a-pfeiffer @alihashmi-wh @XiaoBarry @fumanjie @hls0231 @c-arsen @ncohen-mathematica
+@a-pfeiffer @alihashmi-wh @XiaoBarry @fumanjie @hls0231 @c-arsen @ncohen-mathematica @MemeBarrett 


### PR DESCRIPTION
Add Meme Barrett to codeowners

## What is this and why are we doing it?
Meme needs permissions to create/upload branches for code development.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
DBDAART-12789
DBDAART-13289

## What are the security implications from this change?
Meme is an authorized member of the organization.

## How did I test this?
N/A

## Should there be new or updated documentation for this change? (Be specific.)
N/A

## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [ ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
