### PR TITLE
DBDAART-12836 - OTL Adds

### DIFF
--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -94,6 +94,34 @@ class OTL:
                 , { TAF_Closure.var_set_type1('IHS_SVC_IND',upper=True) }
                 ,nullif(trim(ORDRG_PRVDR_NUM),'') as ORDRG_PRVDR_NUM
                 ,nullif(trim(ORDRG_PRVDR_NPI_NUM),'') as ORDRG_PRVDR_NPI_NUM
+                ,case when (DGNS_CD_PNTR_1 >= 1 and DGNS_CD_PNTR_1 <= 12) then DGNS_CD_PNTR_1 else NULL end as DGNS_CD_PNTR_1
+                ,case when (DGNS_CD_PNTR_2 >= 1 and DGNS_CD_PNTR_2 <= 12) then DGNS_CD_PNTR_2 else NULL end as DGNS_CD_PNTR_2
+                ,case when (DGNS_CD_PNTR_3 >= 1 and DGNS_CD_PNTR_3 <= 12) then DGNS_CD_PNTR_3 else NULL end as DGNS_CD_PNTR_3
+                ,case when (DGNS_CD_PNTR_4 >= 1 and DGNS_CD_PNTR_4 <= 12) then DGNS_CD_PNTR_4 else NULL end as DGNS_CD_PNTR_4
+                ,GME_PD_AMT
+                , case when upper(lpad(trim(MBESCBES_SRVC_CTGRY),5,'0')) in {tuple(TAF_Metadata.MBESCBES_SRVC_CTGRY_values)}
+                            then upper(lpad(trim(MBESCBES_SRVC_CTGRY),5,'0'))
+                            else NULL end as MBESCBES_SRVC_CTGRY
+                , case when replace(upper(trim(MBESCBES_FRM)),' ','') in {tuple(x.replace(" ","") for x in TAF_Metadata.MBESCBES_FRM_values)} then upper(trim(MBESCBES_FRM)) else NULL end as MBESCBES_FRM
+                , { TAF_Closure.var_set_type2('MBESCBES_FRM_GRP', 0, cond1='1', cond2='2', cond3='3') }
+                , case when (SRVC_PLC_CD_L is not NULL and ((length(lpad(SRVC_PLC_CD_L,2, '0')) - coalesce(length(regexp_replace(lpad(SRVC_PLC_CD_L,2, '0'), '[0-9]{2}', '')), 0))) > 0) then
+                    case when (cast(SRVC_PLC_CD_L as int) >= 1 and cast(SRVC_PLC_CD_L as int) <= 99) then lpad(SRVC_PLC_CD_L, 2, '0')
+                        else NULL end
+                    else NULL end
+                    as SRVC_PLC_CD_L
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM_L')}
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM_2_L')}
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM_L')}
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM_2_L')}
+                , SDP_ALOWD_AMT
+                , SDP_PD_AMT
+                , {TAF_Closure.var_set_type1('SRVC_FAC_LCTN_ORG_NPI_L')}
+                , {TAF_Closure.var_set_type1('SRVC_FAC_LCTN_ADR_LINE_1_L')}
+                , {TAF_Closure.var_set_type1('SRVC_FAC_LCTN_ADR_LINE_2_L')}
+                , {TAF_Closure.var_set_type1('SRVC_FAC_LCTN_CITY_L')}
+                , {TAF_Closure.var_set_type1('SRVC_FAC_LCTN_STATE_L')}
+                , {TAF_Closure.var_set_type1('SRVC_FAC_LCTN_ZIP_L')}
+                , {TAF_Closure.var_set_type1('UNIQ_DVC_ID')}
             from (
                 select
                     *,

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -367,7 +367,29 @@ class OT_Metadata:
             "XXI_SRVC_CTGRY_CD",
             "IHS_SVC_IND",
             "ORDRG_PRVDR_NUM",
-            "ORDRG_PRVDR_NPI_NUM"
+            "ORDRG_PRVDR_NPI_NUM",
+            "DGNS_CD_PNTR_1",
+            "DGNS_CD_PNTR_2",
+            "DGNS_CD_PNTR_3",
+            "DGNS_CD_PNTR_4",
+            "GME_PD_AMT",
+            "MBESCBES_SRVC_CTGRY_CD",
+            "MBESCBES_FORM",
+            "MBESCBES_FORM_GRP",
+            "SRVC_PLC_CD",
+            "RFRG_PRVDR_NPI_NUM",
+            "RFRG_PRVDR_NPI_NUM_2",
+            "RFRG_PRVDR_NUM",
+            "RFRG_PRVDR_NUM_2",
+            "SDP_ALOWD_AMT",
+            "SDP_PD_AMT",
+            "SRVC_FAC_LCTN_ORGNTN_NPI_NUM",
+            "SRVC_FAC_LCTN_LINE_1_ADR",
+            "SRVC_FAC_LCTN_LINE_2_ADR",
+            "SRVC_FAC_LCTN_CITY_NAME",
+            "SRVC_FAC_LCTN_STATE",
+            "SRVC_FAC_LCTN_ZIP_CD",
+            "UNIQ_DVC_ID"
         ],
         "COT00004": [
             "TMSIS_RUN_ID",
@@ -523,7 +545,12 @@ class OT_Metadata:
         "BLG_PRVDR_CITY_NAME",
         "BLG_PRVDR_STATE_CD",
 		"RFRG_PRVDR_NUM_2",
-		"RFRG_PRVDR_NPI_NUM_2"
+		"RFRG_PRVDR_NPI_NUM_2",
+        "MBESCBES_SRVC_CTGRY_CD",
+        "MBESCBES_FORM",
+        "MBESCBES_FORM_GRP",
+        "SRVC_FAC_LCTN_ORGNTN_NPI_NUM",
+        "UNIQ_DVC_ID"
     ]
 
     renames = {}
@@ -561,6 +588,20 @@ class OT_Metadata:
         "HCPCS_SRVC_CD": "HCBS_SRVC_CD",
         "HCPCS_TXNMY_CD": "HCBS_TXNMY",
         "NDC_UOM_CD": "UOM_CD",
+        "MBESCBES_SRVC_CTGRY_CD":"MBESCBES_SRVC_CTGRY",
+        "MBESCBES_FORM":"MBESCBES_FRM",
+        "MBESCBES_FORM_GRP":"MBESCBES_FRM_GRP",
+        "SRVC_PLC_CD":"SRVC_PLC_CD_L",
+        "RFRG_PRVDR_NPI_NUM":"RFRG_PRVDR_NPI_NUM_L",
+        "RFRG_PRVDR_NPI_NUM_2":"RFRG_PRVDR_NPI_NUM_2_L",
+        "RFRG_PRVDR_NUM":"RFRG_PRVDR_NUM_L",
+        "RFRG_PRVDR_NUM_2":"RFRG_PRVDR_NUM_2_L",
+        "SRVC_FAC_LCTN_ORGNTN_NPI_NUM":"SRVC_FAC_LCTN_ORG_NPI_L",
+        "SRVC_FAC_LCTN_LINE_1_ADR":"SRVC_FAC_LCTN_ADR_LINE_1_L",
+        "SRVC_FAC_LCTN_LINE_2_ADR":"SRVC_FAC_LCTN_ADR_LINE_2_L",
+        "SRVC_FAC_LCTN_CITY_NAME":"SRVC_FAC_LCTN_CITY_L",
+        "SRVC_FAC_LCTN_STATE":"SRVC_FAC_LCTN_STATE_L",
+        "SRVC_FAC_LCTN_ZIP_CD":"SRVC_FAC_LCTN_ZIP_L"
     }
 
     header_columns = [
@@ -789,7 +830,29 @@ class OT_Metadata:
         "SRVCNG_PRVDR_NPPES_TXNMY_CD",
         "IHS_SVC_IND",
         "ORDRG_PRVDR_NUM",
-        "ORDRG_PRVDR_NPI_NUM"
+        "ORDRG_PRVDR_NPI_NUM",
+        "DGNS_CD_PNTR_1",
+        "DGNS_CD_PNTR_2",
+        "DGNS_CD_PNTR_3",
+        "DGNS_CD_PNTR_4",
+        "GME_PD_AMT",
+        "MBESCBES_SRVC_CTGRY",
+        "MBESCBES_FRM",
+        "MBESCBES_FRM_GRP",
+        "SRVC_PLC_CD_L",
+        "RFRG_PRVDR_NPI_NUM_L",
+        "RFRG_PRVDR_NPI_NUM_2_L",
+        "RFRG_PRVDR_NUM_L",
+        "RFRG_PRVDR_NUM_2_L",
+        "SDP_ALOWD_AMT",
+        "SDP_PD_AMT",
+        "SRVC_FAC_LCTN_ORG_NPI_L",
+        "SRVC_FAC_LCTN_ADR_LINE_1_L",
+        "SRVC_FAC_LCTN_ADR_LINE_2_L",
+        "SRVC_FAC_LCTN_CITY_L",
+        "SRVC_FAC_LCTN_STATE_L",
+        "SRVC_FAC_LCTN_ZIP_L",
+        "UNIQ_DVC_ID"
     ]
     
     dx_columns = [


### PR DESCRIPTION
## What is this and why are we doing it?
Adding new elements to TAF_OTL file.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-12836

## What are the security implications from this change?
N/A

## How did I test this?
Visual inspection of the changes to the SQL plan:
Elicited one unexpected change.   The SRVC_FAC_LCTN_ORG_NPI field is added to both the header and line level.   In the header specs, it is not upper cased.   In the line specs, it is upper cased.  When I added it to the upper list, because it has the same TMSIS name in header and line, the header field is now getting upper cased.   Note made in specs regarding this.   Leaving as both line and header being upper cased.

Regression Testing:  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/3867141456113353?o=955724715920583

Summary stats and nullness:   https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/3867141456113388?o=955724715920583

DDL:  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/3867141456113367?o=955724715920583

DDL/Layout comparison in jira ticket.

## Should there be new or updated documentation for this change? (Be specific.)
Done by TAF documentation team. 

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
