### PR TITLE
DBDAART-13297_BSF_Add_Elig_Determinants2

### DIFF
--- a/taf/BSF/BSF_Metadata.py
+++ b/taf/BSF/BSF_Metadata.py
@@ -1383,10 +1383,6 @@ class BSF_Metadata:
             'ELGBL_ZIP_CD',
             'ELGBL_ADR_EFCTV_DT',
             'ELGBL_ADR_END_DT',
-            'ELGBLTY_EXTNSN_CD',
-            'CNTNUS_ELGBLTY_CD',
-            'INCM_STD_CD',
-            'ELGBLTY_RDTRMNTN_DT',
         ],
 
         'ELG00005': [
@@ -1411,7 +1407,11 @@ class BSF_Metadata:
             'TANF_CASH_CD',
             'ELGBLTY_DTRMNT_EFCTV_DT',
             'ELGBLTY_DTRMNT_END_DT',
-            'PRMRY_ELGBLTY_GRP_IND'
+            'PRMRY_ELGBLTY_GRP_IND',
+            'ELGBLTY_EXTNSN_CD',
+            'CNTNUS_ELGBLTY_CD',
+            'INCM_STD_CD',
+            'ELGBLTY_RDTRMNTN_DT',
         ],
 
         'ELG00006': [


### PR DESCRIPTION
Move new vars in BSF_Metadata.py 'columns'
dictionary from ELG00004 to ELG00005.

## What is this and why are we doing it?


* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####


## What are the security implications from this change?


## How did I test this?


## Should there be new or updated documentation for this change? (Be specific.)


## PR Checklist
- [ ] The JIRA ticket number and a short description is in the subject line
- [ ] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
