### PR TITLE
Dbdaart 14106 rename ot ip lt elements

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -175,8 +175,8 @@ class IPH:
                 , { TAF_Closure.var_set_taxo('BLG_PRVDR_TXNMY_CD', cond1='8888888888', cond2='9999999999', cond3='000000000X', cond4='999999999X', cond5='NONE', cond6='XXXXXXXXXX', cond7='NO TAXONOMY') }
                 , { TAF_Closure.var_set_prtype('blg_prvdr_type_cd') }
                 , { TAF_Closure.var_set_spclty('BLG_PRVDR_SPCLTY_CD') }
-                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM') }
-                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM') }
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM_H') }
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM_H') }
                 ,rfrg_prvdr_type_cd
                 ,RFRG_PRVDR_SPCLTY_CD
 

--- a/taf/IP/IP_Metadata.py
+++ b/taf/IP/IP_Metadata.py
@@ -408,7 +408,9 @@ class IP_Metadata:
         "BLG_PRVDR_LINE_2_ADR":"BLG_PRVDR_ADR_LINE_2",
         "BLG_PRVDR_CITY_NAME":"BLG_PRVDR_CITY",
         "BLG_PRVDR_STATE_CD":"BLG_PRVDR_STATE",
-        "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP"
+        "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP",
+        "RFRG_PRVDR_NPI_NUM":"RFRG_PRVDR_NPI_NUM_H",
+        "RFRG_PRVDR_NUM":"RFRG_PRVDR_NUM_H"
     }
 
     line_renames = {
@@ -670,8 +672,8 @@ class IP_Metadata:
         "BLG_PRVDR_TXNMY_CD",
         "BLG_PRVDR_TYPE_CD",
         "BLG_PRVDR_SPCLTY_CD",
-        "RFRG_PRVDR_NUM",
-        "RFRG_PRVDR_NPI_NUM",
+        "RFRG_PRVDR_NUM_H",
+        "RFRG_PRVDR_NPI_NUM_H",
         "RFRG_PRVDR_TYPE_CD",
         "RFRG_PRVDR_SPCLTY_CD",
         "PRVDR_LCTN_ID",

--- a/taf/IP/IP_Runner.py
+++ b/taf/IP/IP_Runner.py
@@ -39,7 +39,7 @@ class IP_Runner(TAF_Runner):
         from taf.IP.IPL import IPL
         from taf.IP.IP_DX import IP_DX
         
-        TMSIS_SCHEMA = "tmsis"
+        TMSIS_SCHEMA = "state_prod_catalog.tmsis"
         
         # number of DX codes to be transposed and added to header file from dx file.
         NUMDX = 12

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -114,8 +114,8 @@ class LTH:
                 , { TAF_Closure.var_set_taxo('BLG_PRVDR_TXNMY_CD', cond1='8888888888', cond2='9999999999', cond3='000000000X', cond4='999999999X', cond5='NONE', cond6='XXXXXXXXXX', cond7='NO TAXONOMY') }
                 , { TAF_Closure.var_set_prtype(var='BLG_PRVDR_TYPE_CD') }
                 , { TAF_Closure.var_set_spclty(var='BLG_PRVDR_SPCLTY_CD') }
-                , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NUM') }
-                , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NPI_NUM') }
+                , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NUM_H') }
+                , { TAF_Closure.var_set_type1(var='RFRG_PRVDR_NPI_NUM_H') }
                 ,RFRG_PRVDR_TYPE_CD
                 ,RFRG_PRVDR_SPCLTY_CD
                 , { TAF_Closure.var_set_type1(var='PRVDR_LCTN_ID') }

--- a/taf/LT/LT_Metadata.py
+++ b/taf/LT/LT_Metadata.py
@@ -409,7 +409,9 @@ class LT_Metadata:
         "BLG_PRVDR_LINE_2_ADR":"BLG_PRVDR_ADR_LINE_2",
         "BLG_PRVDR_CITY_NAME":"BLG_PRVDR_CITY",
         "BLG_PRVDR_STATE_CD":"BLG_PRVDR_STATE",
-        "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP"
+        "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP",
+        "RFRG_PRVDR_NPI_NUM":"RFRG_PRVDR_NPI_NUM_H",
+        "RFRG_PRVDR_NUM":"RFRG_PRVDR_NUM_H"
     }
 
     line_renames = {
@@ -632,8 +634,8 @@ class LT_Metadata:
         "BLG_PRVDR_TXNMY_CD",
         "BLG_PRVDR_TYPE_CD",
         "BLG_PRVDR_SPCLTY_CD",
-        "RFRG_PRVDR_NUM",
-        "RFRG_PRVDR_NPI_NUM",
+        "RFRG_PRVDR_NUM_H",
+        "RFRG_PRVDR_NPI_NUM_H",
         "RFRG_PRVDR_TYPE_CD",
         "RFRG_PRVDR_SPCLTY_CD",
         "PRVDR_LCTN_ID",

--- a/taf/LT/LT_Runner.py
+++ b/taf/LT/LT_Runner.py
@@ -42,7 +42,7 @@ class LT_Runner(TAF_Runner):
         from taf.LT.LTL import LTL
         from taf.LT.LT_DX import LT_DX
         
-        TMSIS_SCHEMA = "tmsis"
+        TMSIS_SCHEMA = "state_prod_catalog.tmsis"
 
         #number of DX codes to be backfilled to the Header file.
         NUMDX = 5

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -95,8 +95,8 @@ class OTH:
                 , { TAF_Closure.var_set_taxo('BLG_PRVDR_TXNMY_CD', cond1='8888888888', cond2='9999999999', cond3='000000000X', cond4='999999999X', cond5='NONE', cond6='XXXXXXXXXX', cond7='NO TAXONOMY') }
                 , { TAF_Closure.var_set_prtype('blg_prvdr_type_cd') }
                 , { TAF_Closure.var_set_spclty('BLG_PRVDR_SPCLTY_CD') }
-                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM') }
-                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM') }
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NUM_H') }
+                , { TAF_Closure.var_set_type1('RFRG_PRVDR_NPI_NUM_H') }
                 ,RFRG_PRVDR_TXNMY_CD
                 ,RFRG_PRVDR_TYPE_CD
                 ,RFRG_PRVDR_SPCLTY_CD

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -88,7 +88,7 @@ class OTH:
                 , { TAF_Closure.var_set_fills('DGNS_2_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
                 , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
                 , DGNS_POA_2_CD_IND
-                , { TAF_Closure.var_set_type1('SRVC_PLC_CD_H', upper=True, lpad=2) }
+                , { TAF_Closure.var_set_type1('SRVC_PLC_CD', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type1('PRVDR_LCTN_ID') }
                 , { TAF_Closure.var_set_type1('BLG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1('BLG_PRVDR_NPI_NUM') }

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -88,7 +88,7 @@ class OTH:
                 , { TAF_Closure.var_set_fills('DGNS_2_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
                 , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
                 , DGNS_POA_2_CD_IND
-                , { TAF_Closure.var_set_type1('SRVC_PLC_CD', upper=True, lpad=2) }
+                , { TAF_Closure.var_set_type1('SRVC_PLC_CD_H', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type1('PRVDR_LCTN_ID') }
                 , { TAF_Closure.var_set_type1('BLG_PRVDR_NUM') }
                 , { TAF_Closure.var_set_type1('BLG_PRVDR_NPI_NUM') }

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -570,7 +570,6 @@ class OT_Metadata:
         "BLG_PRVDR_CITY_NAME":"BLG_PRVDR_CITY",
         "BLG_PRVDR_STATE_CD":"BLG_PRVDR_STATE",
         "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP",
-        "SRVC_PLC_CD":"SRVC_PLC_CD_H",
         "RFRG_PRVDR_NPI_NUM":"RFRG_PRVDR_NPI_NUM_H",
         "RFRG_PRVDR_NUM":"RFRG_PRVDR_NUM_H",
     }
@@ -652,7 +651,7 @@ class OT_Metadata:
         "DGNS_2_CD",
         "DGNS_2_CD_IND",
         "DGNS_POA_2_CD_IND",
-        "SRVC_PLC_CD_H",
+        "SRVC_PLC_CD as SRVC_PLC_CD_H",
         "PRVDR_LCTN_ID",
         "BLG_PRVDR_NUM",
         "BLG_PRVDR_NPI_NUM",

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -570,7 +570,9 @@ class OT_Metadata:
         "BLG_PRVDR_CITY_NAME":"BLG_PRVDR_CITY",
         "BLG_PRVDR_STATE_CD":"BLG_PRVDR_STATE",
         "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP",
-        "SRVC_PLC_CD":"SRVC_PLC_CD_H"
+        "SRVC_PLC_CD":"SRVC_PLC_CD_H",
+        "RFRG_PRVDR_NPI_NUM":"RFRG_PRVDR_NPI_NUM_H",
+        "RFRG_PRVDR_NUM":"RFRG_PRVDR_NUM_H",
     }
 
     dx_renames = {}
@@ -657,8 +659,8 @@ class OT_Metadata:
         "BLG_PRVDR_TXNMY_CD",
         "BLG_PRVDR_TYPE_CD",
         "BLG_PRVDR_SPCLTY_CD",
-        "RFRG_PRVDR_NUM",
-        "RFRG_PRVDR_NPI_NUM",
+        "RFRG_PRVDR_NUM_H",
+        "RFRG_PRVDR_NPI_NUM_H",
         "RFRG_PRVDR_TXNMY_CD",
         "RFRG_PRVDR_TYPE_CD",
         "RFRG_PRVDR_SPCLTY_CD",

--- a/taf/OT/OT_Metadata.py
+++ b/taf/OT/OT_Metadata.py
@@ -569,7 +569,8 @@ class OT_Metadata:
         "BLG_PRVDR_LINE_2_ADR":"BLG_PRVDR_ADR_LINE_2",
         "BLG_PRVDR_CITY_NAME":"BLG_PRVDR_CITY",
         "BLG_PRVDR_STATE_CD":"BLG_PRVDR_STATE",
-        "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP"
+        "BLG_PRVDR_ZIP_CD":"BLG_PRVDR_ZIP",
+        "SRVC_PLC_CD":"SRVC_PLC_CD_H"
     }
 
     dx_renames = {}
@@ -649,7 +650,7 @@ class OT_Metadata:
         "DGNS_2_CD",
         "DGNS_2_CD_IND",
         "DGNS_POA_2_CD_IND",
-        "SRVC_PLC_CD",
+        "SRVC_PLC_CD_H",
         "PRVDR_LCTN_ID",
         "BLG_PRVDR_NUM",
         "BLG_PRVDR_NPI_NUM",

--- a/taf/OT/OT_Runner.py
+++ b/taf/OT/OT_Runner.py
@@ -40,7 +40,7 @@ class OT_Runner(TAF_Runner):
         from taf.OT.OTL import OTL
         from taf.OT.OT_DX import OT_DX
         
-        TMSIS_SCHEMA = "tmsis"
+        TMSIS_SCHEMA = "state_prod_catalog.tmsis"
 
         #TAF 9.0:  Number of DX codes to be backfilled to header file.
         NUMDX = 2

--- a/taf/RX/RX_Runner.py
+++ b/taf/RX/RX_Runner.py
@@ -40,7 +40,7 @@ class RX_Runner(TAF_Runner):
         from taf.RX.RXL import RXL
         from taf.RX.RX_DX import RX_DX
         
-        TMSIS_SCHEMA = "tmsis"
+        TMSIS_SCHEMA = "state_prod_catalog.tmsis"
 
         # -------------------------------------------------
         #   Produces:


### PR DESCRIPTION
## What is this and why are we doing it?
Renaming fields to differentiate from line level fields with the same name.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-14106
https://jiraent.cms.gov/browse/DBDAART-14107

## What are the security implications from this change?
N/A

## How did I test this?

DDL Changes:  

https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/259667913688221?o=955724715920583

Visual inspection of the SQL Plan changes:  See attached before/after sqls on Jira ticket.

Regression Testing for 3 file types:

OT:  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/259667913688222?o=955724715920583

IP:  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/259667913688241?o=955724715920583

LT:  https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/259667913688232?o=955724715920583

Code merge testing done in the ticket.

## Should there be new or updated documentation for this change? (Be specific.)
Conducted by the TAF documentation team.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
