### PR TITLE
DBDAART-15349 - OTL - SRVC_PLC_CD_L field bug

### DIFF
--- a/taf/OT/OTL.py
+++ b/taf/OT/OTL.py
@@ -104,7 +104,7 @@ class OTL:
                             else NULL end as MBESCBES_SRVC_CTGRY
                 , case when replace(upper(trim(MBESCBES_FRM)),' ','') in {tuple(x.replace(" ","") for x in TAF_Metadata.MBESCBES_FRM_values)} then upper(trim(MBESCBES_FRM)) else NULL end as MBESCBES_FRM
                 , { TAF_Closure.var_set_type2('MBESCBES_FRM_GRP', 0, cond1='1', cond2='2', cond3='3') }
-                , case when (SRVC_PLC_CD_L is not NULL and ((length(lpad(SRVC_PLC_CD_L,2, '0')) - coalesce(length(regexp_replace(lpad(SRVC_PLC_CD_L,2, '0'), '[0-9]{2}', '')), 0))) > 0) then
+                , case when (SRVC_PLC_CD_L is not NULL and ((length(lpad(SRVC_PLC_CD_L,2, '0')) - coalesce(length(regexp_replace(lpad(SRVC_PLC_CD_L,2, '0'), '[0-9]{{2}}', '')), 0))) > 0) then
                     case when (cast(SRVC_PLC_CD_L as int) >= 1 and cast(SRVC_PLC_CD_L as int) <= 99) then lpad(SRVC_PLC_CD_L, 2, '0')
                         else NULL end
                     else NULL end


### PR DESCRIPTION
## What is this and why are we doing it?
IV&V found discrepancy that was a big in the cleaning for the field SRVC_PLC_CD_L in OTL/OTL_D.

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-15349

## What are the security implications from this change?
N/A

## How did I test this?
Unit testing of SRVC_PLC_CD_L  and regression tested all other fields in testing notebook:
https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/989565155444102?o=955724715920583



## Should there be new or updated documentation for this change? (Be specific.)
N/A

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
