### PR TITLE
Dbdaart 15350 fix dgns cd ind

### DIFF
--- a/taf/IP/IPH.py
+++ b/taf/IP/IPH.py
@@ -97,42 +97,42 @@ class IPH:
                     else cast(BIRTH_WT_GRMS_QTY as decimal(9, 3)) end as BIRTH_WT_GRMS_QTY
 
                 , { TAF_Closure.var_set_fills('ADMTG_DGNS_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('ADMTG_DGNS_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('ADMTG_DGNS_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_fills('DGNS_1_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_1_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_1_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_1_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_2_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_2_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_3_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_3_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_3_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_3_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_4_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_4_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_4_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_4_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_5_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_5_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_5_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_5_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_6_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_6_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_6_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_6_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_7_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_7_CD_IND', 0, cond1='1', cond2=2, cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_7_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_7_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_8_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_8_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_8_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_8_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_9_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_9_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_9_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_9_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_10_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_10_CD_IND', 0, cond1=1, cond2=2, cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_10_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_10_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_11_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_11_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_11_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_11_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_12_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_12_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_12_CD_IND', 0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_12_CD_IND') }
 
                 , DRG_CD

--- a/taf/IP/IP_DX.py
+++ b/taf/IP/IP_DX.py
@@ -38,7 +38,7 @@ class IP_DX:
                 end as ADJDCTN_DT
             , case when trim(upper(dgns_type_cd)) in {tuple(TAF_Metadata.DGNS_TYPE_CD_values)} then trim(upper(dgns_type_cd)) else NULL end as DGNS_TYPE_CD
             , DGNS_SQNC_NUM
-            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2') }
             ,{ TAF_Closure.var_set_type1('DGNS_CD') }
             ,{ TAF_Closure.var_set_type4('DGNS_POA_IND', 'YES', cond1='Y', cond2='N', cond3='U', cond4='W', cond5='1') }
             ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS

--- a/taf/LT/LTH.py
+++ b/taf/LT/LTH.py
@@ -82,21 +82,21 @@ class LTH:
                 , { TAF_Closure.var_set_type2(var='HLTH_CARE_ACQRD_COND_CD', lpad=0, cond1='0', cond2='1') }
                 , { TAF_Closure.var_set_ptstatus('PTNT_STUS_CD') }
                 , { TAF_Closure.var_set_fills('ADMTG_DGNS_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2(var='ADMTG_DGNS_CD_IND', lpad=0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2(var='ADMTG_DGNS_CD_IND', lpad=0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_fills('DGNS_1_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2(var='DGNS_1_CD_IND', lpad=0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2(var='DGNS_1_CD_IND', lpad=0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_1_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_2_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2(var='DGNS_2_CD_IND', lpad=0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2(var='DGNS_2_CD_IND', lpad=0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_2_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_3_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2(var='DGNS_3_CD_IND', lpad=0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2(var='DGNS_3_CD_IND', lpad=0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_3_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_4_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2(var='DGNS_4_CD_IND', lpad=0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2(var='DGNS_4_CD_IND', lpad=0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_4_CD_IND') }
                 , { TAF_Closure.var_set_fills('DGNS_5_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2(var='DGNS_5_CD_IND', lpad=0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2(var='DGNS_5_CD_IND', lpad=0, cond1='1', cond2='2') }
                 , { TAF_Closure.var_set_poa('DGNS_POA_5_CD_IND') }
                 , { TAF_Closure.var_set_type6('NCVRD_DAYS_CNT', cond1='88888') }
                 , { TAF_Closure.var_set_type6('NCVRD_CHRGS_AMT', cond1='888888888.88') }

--- a/taf/LT/LT_DX.py
+++ b/taf/LT/LT_DX.py
@@ -39,7 +39,7 @@ class LT_DX:
                 end as ADJDCTN_DT
             , case when trim(upper(dgns_type_cd)) in {tuple(TAF_Metadata.DGNS_TYPE_CD_values)} then trim(upper(dgns_type_cd)) else NULL end as DGNS_TYPE_CD
             ,DGNS_SQNC_NUM
-            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2') }
             ,{ TAF_Closure.var_set_type1('DGNS_CD') }
             ,{ TAF_Closure.var_set_type4('DGNS_POA_IND', 'YES', cond1='Y', cond2='N', cond3='U', cond4='W', cond5='1') }
             ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS

--- a/taf/OT/OTH.py
+++ b/taf/OT/OTH.py
@@ -83,10 +83,10 @@ class OTH:
                 , { TAF_Closure.var_set_type1('MDCR_BENE_ID') }
                 , { TAF_Closure.var_set_type2('HLTH_CARE_ACQRD_COND_CD', 0, cond1='0', cond2='1') }
                 , { TAF_Closure.var_set_fills('DGNS_1_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_1_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_1_CD_IND', 0, cond1='1', cond2='2') }
                 , DGNS_POA_1_CD_IND
                 , { TAF_Closure.var_set_fills('DGNS_2_CD', cond1='0', cond2='8', cond3='9', cond4='#') }
-                , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+                , { TAF_Closure.var_set_type2('DGNS_2_CD_IND', 0, cond1='1', cond2='2') }
                 , DGNS_POA_2_CD_IND
                 , { TAF_Closure.var_set_type1('SRVC_PLC_CD', upper=True, lpad=2) }
                 , { TAF_Closure.var_set_type1('PRVDR_LCTN_ID') }

--- a/taf/OT/OT_DX.py
+++ b/taf/OT/OT_DX.py
@@ -40,7 +40,7 @@ class OT_DX:
                 end as ADJDCTN_DT
             , case when trim(upper(dgns_type_cd)) in {tuple(TAF_Metadata.DGNS_TYPE_CD_values)} then trim(upper(dgns_type_cd)) else NULL end as DGNS_TYPE_CD
             , DGNS_SQNC_NUM
-            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2') }
             ,DGNS_CD
             ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
             ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline

--- a/taf/RX/RX_DX.py
+++ b/taf/RX/RX_DX.py
@@ -39,7 +39,7 @@ class RX_DX:
                 end as ADJDCTN_DT
             ,{ TAF_Closure.var_set_type4('DGNS_TYPE_CD', 'YES', cond1='A', cond2='D', cond3='E', cond4='O', cond5='P', cond6='R') }
             , DGNS_SQNC_NUM
-            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2', cond3='3') }
+            ,{ TAF_Closure.var_set_type2('DGNS_CD_IND', 0, cond1='1', cond2='2') }
             ,DGNS_CD
             ,from_utc_timestamp(current_timestamp(), 'EST') as REC_ADD_TS
             ,from_utc_timestamp(current_timestamp(), 'EST') as REC_UPDT_TS             --this must be equal to REC_ADD_TS for CCW pipeline


### PR DESCRIPTION
## What is this and why are we doing it?
Valid value 3 for dgns cd indicators removed, these are no longer valid values. 

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
https://jiraent.cms.gov/browse/DBDAART-15350

## What are the security implications from this change?
N/A

## How did I test this?
Code merge testing, 
unit testing and regression testing in this notebook:  
https://cms-dataconnect-val.cloud.databricks.com/editor/notebooks/407114359842575?o=955724715920583

## Should there be new or updated documentation for this change? (Be specific.)
No.

## PR Checklist
- [ x] The JIRA ticket number and a short description is in the subject line
- [ x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
