### PR TITLE
MCP DBDAART-15686 & DBDAART-15932: identify CSO and use MCR header record

### DIFF
--- a/taf/MCP/MCP.py
+++ b/taf/MCP/MCP.py
@@ -132,7 +132,7 @@ class MCP(TAF):
                 state_submsn_type s
             on
                 T.submitting_state = s.submtg_state_cd
-                and upper(s.fil_type) = 'MCP'
+                and upper(s.fil_type) = 'MCR'
 
             where
                 (

--- a/taf/MCP/MCP01.py
+++ b/taf/MCP/MCP01.py
@@ -4,7 +4,7 @@ from taf.MCP.MCP_Metadata import MCP_Metadata
 
 class MCP01(MCP):
     """
-    Description:  Selection Functions for the T-MSIS provider segments
+    Description:  Selection Functions for the T-MSIS managed care segments
     """
      
     def __init__(self, mcp: MCP_Runner):
@@ -19,12 +19,12 @@ class MCP01(MCP):
          
         cols01 = ["tms_run_id", "submitting_state"]
 
-        # copy provider header table
+        # copy managed care header table
         self.copy_activerows_nts(
-            "tmsis.File_Header_Record_Provider", cols01, "MC01_Header_Copy"
+            "tmsis.file_header_record_managed_care", cols01, "MC01_Header_Copy"
         )
 
-        # self.mcp.countrows('Prov01_Header_Copy', 'cnt_active', 'PRV01_Active')
+        # self.mcp.countrows('MC01_Header_Copy', 'cnt_active', 'MC01_Active')
 
         # extract the latest (largest) run for each state and identify CHIP/TPA states
         # distkey(submitting_state)

--- a/taf/MCP/MCP02.py
+++ b/taf/MCP/MCP02.py
@@ -5,7 +5,7 @@ from taf.TAF_Closure import TAF_Closure
 
 class MCP02(MCP):
     """
-    Description:  Selection Functions for the T-MSIS provider segments
+    Description:  Selection Functions for the T-MSIS managed care segments
     """
      
     def __init__(self, mcp: MCP_Runner):


### PR DESCRIPTION
IBM should approve first, then Mathematica. Please approve but do not complete PR. Thanks, Meme


## What is this and why are we doing it?
MCP bug fixes.
1) use MCR header to identify states and run ID  in code not provider header
 - MC01.py update comments to say "managed care" instead of "provider"
 - MC01.py change code to use "tmsis.file_header_record_managed_care" to create MC01_Header_Copy
 - MC01.py change commented out code for countrows to MC01_Header_Copy and MC01_Active
 - MC02.py update comments to say "managed care" instead of "provider" 
2) use "MCR" for fil_dt to identify CSO states
 - MCP.py use fil_type='MCR' (line 135) to identify CSO

* Link to the Jira ticket for this change: https://jiraent.cms.gov/browse/DBDAART-####
1) DBDAART-15932 (https://jiraent.cms.gov/browse/DBDAART-15932): MCP: Python code should check MCR header record, not PRV header record
2) DBDAART-15686](https://jiraent.cms.gov/browse/DBDAART-15686): Fix and unit test the defect in mcp.py

## What are the security implications from this change?
none

## How did I test this?
Using synthetic T-MSIS data, built synthetic TAF MCP v9.0 using current TAF code and built synthetic TAF MCP v9.1 using code updates. Compared results.

## Should there be new or updated documentation for this change? (Be specific.)
Done. Updated MCP technical specs clarifies record for fil_type ‘MCR’ is used to identify CSO (TAF MCP Technical Specifications_PI11.docx). Other ticket is fixing bug in code and does not need documentation update.

## PR Checklist
- [x] The JIRA ticket number and a short description is in the subject line
- [x] My code follows any applicable [style guides](https://cms-dataconnect.atlassian.net/wiki/search?text=style%20guide)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
